### PR TITLE
[20241210] Update `DateTimeUtils` functions

### DIFF
--- a/etl-core/src/main/java/com/github/davidch93/etl/core/constants/MetadataField.java
+++ b/etl-core/src/main/java/com/github/davidch93/etl/core/constants/MetadataField.java
@@ -61,6 +61,7 @@ public final class MetadataField {
     public static final String ORD = "_ord";
     public static final String LSN = "_lsn";
     public static final String AUDIT_WRITE_TIME = "_audit_write_time";
+    public static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss z";
 
     // ETL Job History
     public static final String BQ_TABLE_NAME = "bq_table_name";

--- a/etl-core/src/main/java/com/github/davidch93/etl/core/utils/DateTimeUtils.java
+++ b/etl-core/src/main/java/com/github/davidch93/etl/core/utils/DateTimeUtils.java
@@ -60,33 +60,33 @@ public final class DateTimeUtils {
     }
 
     /**
-     * Formats a given epoch timestamp (in milliseconds) into a formatted date-time string
+     * Formats a given {@link Instant} into a formatted date-time string
      * in UTC with the specified format.
      *
-     * @param epochMillis the epoch timestamp in milliseconds
-     * @param format      the desired date-time format (e.g., "yyyy-MM-dd HH:mm:ss")
+     * @param instant the {@link Instant} to format
+     * @param format  the desired date-time format (e.g., "yyyy-MM-dd HH:mm:ss")
      * @return the formatted date-time string
-     * @throws NullPointerException if {@code format} is null
+     * @throws NullPointerException if {@code instant} or {@code format} is null
      */
-    public static String formatEpochMillis(long epochMillis, String format) {
-        return formatEpochMillis(epochMillis, format, ZoneId.of("UTC"));
+    public static String formatInstant(Instant instant, String format) {
+        return formatInstant(instant, format, ZoneId.of("UTC"));
     }
 
     /**
-     * Formats a given epoch timestamp (in milliseconds) into a formatted date-time string
+     * Formats a given {@link Instant} into a formatted date-time string
      * in the specified time zone and format.
      *
-     * @param epochMillis the epoch timestamp in milliseconds
-     * @param format      the desired date-time format (e.g., "yyyy-MM-dd HH:mm:ss")
-     * @param zoneId      the time zone to consider
+     * @param instant the {@link Instant} to format
+     * @param format  the desired date-time format (e.g., "yyyy-MM-dd HH:mm:ss")
+     * @param zoneId  the time zone to consider
      * @return the formatted date-time string
-     * @throws NullPointerException if {@code format} or {@code zoneId} is null
+     * @throws NullPointerException if {@code instant}, {@code format}, or {@code zoneId} is null
      */
-    public static String formatEpochMillis(long epochMillis, String format, ZoneId zoneId) {
+    public static String formatInstant(Instant instant, String format, ZoneId zoneId) {
+        Objects.requireNonNull(instant, "Instant cannot be null!");
         Objects.requireNonNull(format, "Format cannot be null!");
         Objects.requireNonNull(zoneId, "ZoneId cannot be null!");
 
-        Instant instant = Instant.ofEpochMilli(epochMillis);
         ZonedDateTime zonedDateTime = instant.atZone(zoneId);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
         return zonedDateTime.format(formatter);

--- a/etl-core/src/test/java/com/github/davidch93/etl/core/utils/DateTimeUtilsTest.java
+++ b/etl-core/src/test/java/com/github/davidch93/etl/core/utils/DateTimeUtilsTest.java
@@ -2,6 +2,7 @@ package com.github.davidch93.etl.core.utils;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -29,6 +30,7 @@ class DateTimeUtilsTest {
     void testGetStartOfDay_withValidInput() {
         String input = "2024-12-01T12:34:56";
         ZoneId zoneId = ZoneId.of("Asia/Jakarta");
+
         ZonedDateTime startOfDay = DateTimeUtils.getStartOfDay(input, zoneId);
         assertThat(startOfDay.toString()).isEqualTo("2024-12-01T00:00+07:00[Asia/Jakarta]");
     }
@@ -41,33 +43,51 @@ class DateTimeUtilsTest {
     }
 
     @Test
-    void testFormatEpochMillis_withDefaultZone() {
-        long epochMillis = 1733056496000L; // 2024-12-01T12:34:56 UTC
+    void testFormatInstant_withDefaultZone() {
+        Instant instant = Instant.parse("2024-12-10T12:34:56Z");
         String format = "yyyy-MM-dd HH:mm:ss";
-        String result = DateTimeUtils.formatEpochMillis(epochMillis, format);
-        assertThat(result).isEqualTo("2024-12-01 12:34:56");
+
+        String result = DateTimeUtils.formatInstant(instant, format);
+        assertThat(result).isEqualTo("2024-12-10 12:34:56");
     }
 
     @Test
-    void testFormatEpochMillis_withCustomZone() {
-        long epochMillis = 1733056496000L; // 2024-12-01T12:34:56 UTC
+    void testFormatInstant_withCustomZone() {
+        Instant instant = Instant.parse("2024-12-10T12:34:56Z");
         String format = "yyyy-MM-dd HH:mm:ss";
         ZoneId zoneId = ZoneId.of("Asia/Jakarta");
-        String result = DateTimeUtils.formatEpochMillis(epochMillis, format, zoneId);
-        assertThat(result).isEqualTo("2024-12-01 19:34:56");
+
+        String result = DateTimeUtils.formatInstant(instant, format, zoneId);
+        assertThat(result).isEqualTo("2024-12-10 19:34:56");
     }
 
     @Test
-    void testFormatEpochMillis_withNullFormat_expectThrowsException() {
-        assertThatThrownBy(() -> DateTimeUtils.formatEpochMillis(1704065696000L, null, ZoneId.of("UTC")))
+    void testFormatInstant_withNullInstant_expectThrowsException() {
+        String format = "yyyy-MM-dd HH:mm:ss";
+        ZoneId zoneId = ZoneId.of("UTC");
+
+        assertThatThrownBy(() -> DateTimeUtils.formatInstant(null, format, zoneId))
             .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining("Format cannot be null!");
+            .hasMessage("Instant cannot be null!");
     }
 
     @Test
-    void testFormatEpochMillis_withNullZoneId_expectThrowsException() {
-        assertThatThrownBy(() -> DateTimeUtils.formatEpochMillis(1704065696000L, "yyyy-MM-dd", null))
+    void testFormatInstant_withNullFormat_expectThrowsException() {
+        Instant instant = Instant.now();
+        ZoneId zoneId = ZoneId.of("UTC");
+
+        assertThatThrownBy(() -> DateTimeUtils.formatInstant(instant, null, zoneId))
             .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining("ZoneId cannot be null!");
+            .hasMessage("Format cannot be null!");
+    }
+
+    @Test
+    void testFormatInstant_withNullZoneId_expectThrowsException() {
+        Instant instant = Instant.now();
+        String format = "yyyy-MM-dd HH:mm:ss";
+
+        assertThatThrownBy(() -> DateTimeUtils.formatInstant(instant, format, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("ZoneId cannot be null!");
     }
 }


### PR DESCRIPTION
## Updates
- [x] Replaced `epochMillis` with `Instant` parameters and renamed its function into `formatInstant`.