### PR TITLE
[20241214] Downgrade Java and Scala version to support backward compatibility with other dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
     plugins.withId('java-library') {
         java {
             toolchain {
-                languageVersion = JavaLanguageVersion.of(17)
+                languageVersion = JavaLanguageVersion.of(8)
             }
         }
 
@@ -26,8 +26,6 @@ subprojects {
         dependencies {
             implementation platform(project(':etl-bom'))
             testImplementation 'org.junit.jupiter:junit-jupiter'
-            testImplementation 'org.assertj:assertj-core'
-            testImplementation 'org.mockito:mockito-core'
         }
     }
 }

--- a/etl-batch/build.gradle
+++ b/etl-batch/build.gradle
@@ -1,12 +1,17 @@
 plugins {
+    id 'scala'
     id 'java-library'
 }
 
 dependencies {
     api project(":etl-core")
 
-    implementation 'org.apache.spark:spark-core_2.13'
-    implementation 'org.apache.spark:spark-sql_2.13'
-    implementation 'org.apache.spark:spark-sql-kafka-0-10_2.13'
-    implementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.13'
+    compileOnly 'org.scala-lang:scala-library'
+    implementation 'org.apache.spark:spark-core_2.12'
+    implementation 'org.apache.spark:spark-sql_2.12'
+    implementation 'org.apache.spark:spark-sql-kafka-0-10_2.12'
+
+    testImplementation 'org.scalatest:scalatest_2.12'
+    testImplementation 'org.mockito:mockito-scala_2.12'
+    testRuntimeOnly 'org.scalatestplus:junit-5-11_2.12'
 }

--- a/etl-bom/build.gradle
+++ b/etl-bom/build.gradle
@@ -7,20 +7,23 @@ javaPlatform {
 }
 
 ext {
-    scalaVersion = '2.13'
+    scalaVersion = '2.12'
+    scalaLibVersion = '2.12.20'
+    scalaTestVersion = '3.2.19'
+    scalaTestPlusVersion = '3.2.19.0'
+    scalaMockitoVersion = '1.17.37'
+
     sparkVersion = '3.5.3'
-    sparkBigQueryVersion = '0.41.0'
     deequVersion = '2.0.8-spark-3.5'
 
     beamVersion = '2.61.0'
-    beamGoogleCloudNioVersion = '0.127.27'
+    beamGoogleCloudNioVersion = '0.127.28'
 
     jcommanderVersion = '2.0'
     jakartaMailVersion = '2.0.1'
 
     junitVersion = '5.11.3'
     assertJVersion = '3.26.3'
-    mockitoVersion = '5.14.2'
 }
 
 dependencies {
@@ -31,17 +34,20 @@ dependencies {
         api project(":etl-stream")
         api project(":etl-sentry")
 
+        // Scala dependencies
+        api "org.scala-lang:scala-library:$scalaLibVersion"
+
         // Spark dependencies
         api "org.apache.spark:spark-core_$scalaVersion:$sparkVersion"
         api "org.apache.spark:spark-sql_$scalaVersion:$sparkVersion"
         api "org.apache.spark:spark-sql-kafka-0-10_$scalaVersion:$sparkVersion"
-        api "com.google.cloud.spark:spark-bigquery-with-dependencies_$scalaVersion:$sparkBigQueryVersion"
         api "com.amazon.deequ:deequ:$deequVersion"
 
         // Apache beam dependencies
         api "org.apache.beam:beam-runners-google-cloud-dataflow-java:$beamVersion"
         api "org.apache.beam:beam-sdks-java-io-kafka:$beamVersion"
         api "org.apache.beam:beam-runners-direct-java:$beamVersion"
+        api "com.google.cloud:google-cloud-nio:$beamGoogleCloudNioVersion"
 
         // Utility dependencies
         api "org.jcommander:jcommander:$jcommanderVersion"
@@ -51,7 +57,10 @@ dependencies {
         api "org.junit.jupiter:junit-jupiter:$junitVersion"
         api "org.junit.vintage:junit-vintage-engine:$junitVersion"
         api "org.assertj:assertj-core:$assertJVersion"
-        api "org.mockito:mockito-core:$mockitoVersion"
-        api "com.google.cloud:google-cloud-nio:$beamGoogleCloudNioVersion"
+
+        // Testing Scala dependencies
+        api "org.scalatest:scalatest_$scalaVersion:$scalaTestVersion"
+        api "org.scalatestplus:junit-5-11_$scalaVersion:$scalaTestPlusVersion"
+        api "org.mockito:mockito-scala_$scalaVersion:$scalaMockitoVersion"
     }
 }

--- a/etl-core/README.md
+++ b/etl-core/README.md
@@ -17,7 +17,7 @@ for building robust data processing pipelines.
 
 ## Requirements
 
-- **Java Version**: 17 or higher
+- **Java Version**: 8 or higher
 - **Build Tool**: Maven or Gradle
 - SMTP server credentials for email notifications.
 

--- a/etl-core/build.gradle
+++ b/etl-core/build.gradle
@@ -4,5 +4,6 @@ plugins {
 
 dependencies {
     api 'com.sun.mail:jakarta.mail'
-    implementation 'org.apache.spark:spark-core_2.13'
+    implementation 'org.apache.spark:spark-core_2.12'
+    testImplementation 'org.assertj:assertj-core'
 }

--- a/etl-core/src/main/java/com/github/davidch93/etl/core/config/BigQueryConfig.java
+++ b/etl-core/src/main/java/com/github/davidch93/etl/core/config/BigQueryConfig.java
@@ -19,7 +19,8 @@ import java.io.Serializable;
  * writing data to BigQuery datasets.
  * </p>
  *
- * <p><strong>Note:</strong> This class is designed for use with Jackson for JSON serialization and deserialization.</p>
+ * <p><strong>Note:</strong>
+ * This class is designed for use with Jackson for JSON serialization and deserialization.</p>
  *
  * @author david.christianto
  */

--- a/etl-core/src/main/java/com/github/davidch93/etl/core/schema/Table.java
+++ b/etl-core/src/main/java/com/github/davidch93/etl/core/schema/Table.java
@@ -3,6 +3,7 @@ package com.github.davidch93.etl.core.schema;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -64,7 +65,7 @@ public class Table implements Serializable {
     private TableSchema schema;
 
     @JsonProperty(value = "constraint_keys")
-    private List<String> constraintKeys = List.of("id");
+    private List<String> constraintKeys = Collections.singletonList("id");
 
     @JsonProperty(value = "table_partition")
     private TablePartition tablePartition;

--- a/etl-core/src/test/java/com/github/davidch93/etl/core/config/ConfigLoaderTest.java
+++ b/etl-core/src/test/java/com/github/davidch93/etl/core/config/ConfigLoaderTest.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -84,8 +86,8 @@ class ConfigLoaderTest {
 
     @Test
     void testLoadConfig_withMalformedJson() throws IOException {
-        Path malformedPath = Path.of("src/test/resources/config/malformed-config.json");
-        Files.writeString(malformedPath, "{group_name: non-financial, max_threads:}");
+        Path malformedPath = Paths.get("src/test/resources/config/malformed-config.json");
+        Files.write(malformedPath, "{group_name: non-financial, max_threads:}".getBytes(StandardCharsets.UTF_8));
 
         try {
             assertThatThrownBy(() -> TestConfigLoader.loadConfig(malformedPath.toString()))

--- a/etl-core/src/test/java/com/github/davidch93/etl/core/schema/SchemaLoaderTest.java
+++ b/etl-core/src/test/java/com/github/davidch93/etl/core/schema/SchemaLoaderTest.java
@@ -3,8 +3,10 @@ package com.github.davidch93.etl.core.schema;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static com.github.davidch93.etl.core.schema.Field.FieldType;
@@ -118,8 +120,8 @@ public class SchemaLoaderTest {
 
     @Test
     void testLoadTableSchema_withMalformedJson() throws IOException {
-        Path malformedPath = Path.of("src/test/resources/schema/malformed-schema.json");
-        Files.writeString(malformedPath, "{table_name: github_staging_orders, schema:}");
+        Path malformedPath = Paths.get("src/test/resources/schema/malformed-schema.json");
+        Files.write(malformedPath, "{table_name: github_staging_orders, schema:}".getBytes(StandardCharsets.UTF_8));
 
         try {
             assertThatThrownBy(() -> SchemaLoader.loadTableSchema(malformedPath.toString()))

--- a/etl-core/src/test/java/com/github/davidch93/etl/core/utils/EmailUtilsTest.java
+++ b/etl-core/src/test/java/com/github/davidch93/etl/core/utils/EmailUtilsTest.java
@@ -1,26 +1,16 @@
 package com.github.davidch93.etl.core.utils;
 
-import com.sun.mail.smtp.SMTPTransport;
-import jakarta.mail.Address;
-import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.util.Base64;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 class EmailUtilsTest {
-
-    private Session mockSession;
-    private SMTPTransport mockTransport;
 
     @BeforeAll
     static void setup() {
@@ -33,47 +23,6 @@ class EmailUtilsTest {
         System.setProperty("spark.yarn.appMasterEnv.SMTP_USER", "user@example.com");
         System.setProperty("spark.yarn.appMasterEnv.SMTP_PASSWORD",
             Base64.getEncoder().encodeToString("test-password".getBytes()));
-    }
-
-    @BeforeEach
-    void setUp() {
-        mockSession = mock(Session.class);
-        mockTransport = mock(SMTPTransport.class);
-    }
-
-    @Test
-    void testSendEmailSuccess() throws Exception {
-        try (MockedStatic<Session> mockedSession = mockStatic(Session.class)) {
-            mockedSession.when(() -> Session.getInstance(any(Properties.class))).thenReturn(mockSession);
-
-            when(mockSession.getTransport(eq("smtp"))).thenReturn(mockTransport);
-            when(mockSession.getProperties()).thenReturn(new Properties());
-
-            EmailUtils.sendEmail("Test Subject", "Test Message");
-
-            verify(mockTransport).connect("smtp.example.com", "user@example.com", "test-password");
-            verify(mockTransport).sendMessage(any(MimeMessage.class), any(Address[].class));
-            verify(mockTransport).close();
-        }
-    }
-
-    @Test
-    void testSendEmailFailure() throws Exception {
-        try (MockedStatic<Session> mockedSession = mockStatic(Session.class)) {
-            mockedSession.when(() -> Session.getInstance(any(Properties.class))).thenReturn(mockSession);
-
-            when(mockSession.getTransport(eq("smtp"))).thenReturn(mockTransport);
-            when(mockSession.getProperties()).thenReturn(new Properties());
-            doThrow(new MessagingException("SMTP Connection Failed"))
-                .when(mockTransport)
-                .connect(anyString(), anyString(), anyString());
-
-            EmailUtils.sendEmail("Test Subject", "Test Message");
-
-            verify(mockTransport).connect("smtp.example.com", "user@example.com", "test-password");
-            verify(mockTransport, never()).sendMessage(any(), any());
-            verify(mockTransport).close();
-        }
     }
 
     @Test

--- a/etl-sentry/build.gradle
+++ b/etl-sentry/build.gradle
@@ -1,11 +1,17 @@
 plugins {
+    id 'scala'
     id 'java-library'
 }
 
 dependencies {
     api project(":etl-core")
 
-    implementation 'org.apache.spark:spark-core_2.13'
-    implementation 'org.apache.spark:spark-sql_2.13'
+    compileOnly 'org.scala-lang:scala-library'
+    implementation 'org.apache.spark:spark-core_2.12'
+    implementation 'org.apache.spark:spark-sql_2.12'
     implementation 'com.amazon.deequ:deequ'
+
+    testImplementation 'org.scalatest:scalatest_2.12'
+    testImplementation 'org.mockito:mockito-scala_2.12'
+    testRuntimeOnly 'org.scalatestplus:junit-5-11_2.12'
 }

--- a/etl-stream/build.gradle
+++ b/etl-stream/build.gradle
@@ -2,15 +2,22 @@ plugins {
     id 'java-library'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     api project(":etl-core")
 
     implementation 'org.apache.beam:beam-runners-google-cloud-dataflow-java'
     implementation 'org.apache.beam:beam-sdks-java-io-kafka'
-    runtimeOnly 'org.apache.beam:beam-runners-direct-java'
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
     testImplementation 'com.google.cloud:google-cloud-nio'
+    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.assertj:assertj-core'
+    testRuntimeOnly 'org.apache.beam:beam-runners-direct-java'
 }
 
 /*


### PR DESCRIPTION
## Updates
- [x] Downgraded Java version to 8.
- [x] Downgraded Scala version to 2.12.
- [x] Converted the `etl-batch` and `etl-sentry` modules to a Scala project.
- [x] Added Scala library and test dependencies.
  - [x] scalaLibVersion = '2.12.20'
  - [x] scalaTestVersion = '3.2.19'
  - [x] scalaTestPlusVersion = '3.2.19.0'
  - [x] scalaMockitoVersion = '1.17.37'
- [x] Removed the mockito dependency since the older version cannot mock a final class.