### PR TITLE
[20241220] Add Data Lake transformers in the `etl-batch` module.

### DIFF
--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/constants/Field.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/constants/Field.scala
@@ -1,0 +1,21 @@
+package com.github.davidch93.etl.batch.constants
+
+/**
+ * An object containing constants for tracking the status and details of ETL jobs.
+ *
+ * <strong>Note:</strong>
+ * This object is immutable and all fields are declared as `final` for ease of use.
+ *
+ * @author david.christianto
+ */
+object Field {
+
+  final val TABLE_NAME = "table_name"
+  final val GROUP_NAME = "group_name"
+  final val SCHEDULED_TIMESTAMP = "scheduled_timestamp"
+  final val START_TIMESTAMP = "start_timestamp"
+  final val END_TIMESTAMP = "end_timestamp"
+  final val DURATION_SECONDS = "duration_seconds"
+  final val IS_SUCCESS = "is_success"
+  final val MESSAGE = "message"
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/helpers/SchemaConverter.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/helpers/SchemaConverter.scala
@@ -1,0 +1,74 @@
+package com.github.davidch93.etl.batch.helpers
+
+import com.github.davidch93.etl.core.constants.MetadataField.IS_DELETED
+import com.github.davidch93.etl.core.schema.Field.FieldType
+import com.github.davidch93.etl.core.schema.{TablePartition, TableSchema}
+import org.apache.spark.sql.types._
+
+import scala.collection.JavaConverters._
+
+/**
+ * Utility object for converting `TableSchema` and `TablePartition` metadata to Spark SQL `StructType` schemas.
+ *
+ * @author david.christianto
+ */
+object SchemaConverter {
+
+  /**
+   * Converts a `TableSchema` instance to a Spark SQL `StructType`.
+   *
+   * @param tableSchema The table schema containing field definitions.
+   * @return A `StructType` representation of the table schema.
+   * @throws IllegalArgumentException if the table schema contains unsupported field types.
+   */
+  def tableSchemaToStructType(tableSchema: TableSchema): StructType = {
+    require(tableSchema != null, "The table schema cannot be null!")
+
+    val structFields = tableSchema.getFields.asScala.map { field =>
+      StructField(field.getName, convertFieldTypeToDataType(field.getType), field.isNullable)
+    }.toArray
+
+    new StructType(structFields)
+  }
+
+  /**
+   * Converts a `TableSchema` to a Spark SQL `StructType` with optional metadata columns.
+   *
+   * @param tableSchema    The table schema containing field definitions. Must not be null.
+   * @param tablePartition An optional table partition containing metadata for partition columns.
+   * @return A `StructType` representation of the table schema with metadata columns.
+   */
+  def tableSchemaWithMetadataToStructType(
+    tableSchema: TableSchema,
+    tablePartition: Option[TablePartition] = None
+  ): StructType = {
+    val baseSchema = tableSchemaToStructType(tableSchema)
+
+    tablePartition match {
+      case Some(partition) =>
+        baseSchema
+          .add(partition.getPartitionColumn, TimestampType, nullable = false)
+          .add(IS_DELETED, BooleanType, nullable = false)
+      case None =>
+        baseSchema
+          .add(IS_DELETED, BooleanType, nullable = false)
+    }
+  }
+
+  /**
+   * Converts a `FieldType` to a corresponding Spark SQL `DataType`.
+   *
+   * @param fieldType The field type to be converted.
+   * @return The corresponding Spark SQL `DataType`.
+   * @throws IllegalArgumentException if the field type is unsupported.
+   */
+  private def convertFieldTypeToDataType(fieldType: FieldType): DataType = {
+    fieldType match {
+      case FieldType.BOOLEAN => BooleanType
+      case FieldType.INTEGER => LongType
+      case FieldType.DOUBLE => DoubleType
+      case FieldType.STRING => StringType
+      case _ => throw new IllegalArgumentException(s"Cannot handle type: `$fieldType`!")
+    }
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataLakeDynamoDbTransformer.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataLakeDynamoDbTransformer.scala
@@ -1,0 +1,103 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.constants.MetadataField._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{LongType, StructType}
+import org.apache.spark.sql.{Column, DataFrame}
+
+/**
+ * Object responsible for transforming DynamoDB data ingested from Kafka into two formats:
+ *  - Raw Data Lake format
+ *  - Curated Data Lake format
+ *
+ * This transformation extracts necessary fields, applies schema structures, and formats data
+ * to ensure compatibility for downstream processing.
+ *
+ * @author david.christianto
+ */
+object DataLakeDynamoDbTransformer {
+
+  private val extractedSourceColumns = Array(
+    get_json_object(col(PAYLOAD_SOURCE), s"$$.$PAYLOAD_SOURCE_TS_MS").cast(LongType).as(TS_MS),
+    get_json_object(col(PAYLOAD_SOURCE), s"$$.$PAYLOAD_SOURCE_SHARD_ID").as(SHARD_ID),
+    get_json_object(col(PAYLOAD_SOURCE), s"$$.$PAYLOAD_SOURCE_SEQUENCE_NUMBER").as(SEQUENCE_NUMBER)
+  )
+
+  /**
+   * Transforms a Kafka DataFrame containing DynamoDB change events into a Raw Data Lake format.
+   *
+   * The resulting DataFrame has the following schema:
+   * {{{
+   *   root
+   *    |-- ts_ms: long (nullable = false)
+   *    |-- op: string (nullable = false)
+   *    |-- before: string (nullable = true)
+   *    |-- after: string (nullable = true)
+   *    |-- source: string (nullable = false)
+   *    |-- _datetime_partition: string (nullable = false)
+   * }}}
+   *
+   * @param kafkaDataFrame The input DataFrame containing DynamoDB CDC events in JSON format from Kafka.
+   * @return A DataFrame with fields extracted and formatted for the Raw Data Lake.
+   */
+  def transformToRawDataLake(kafkaDataFrame: DataFrame): DataFrame = {
+    import kafkaDataFrame.sparkSession.implicits._
+
+    kafkaDataFrame
+      .withColumn(PAYLOAD_TS_MS, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_TS_MS").cast(LongType))
+      .withColumn(PAYLOAD_OP, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_OP"))
+      .withColumn(PAYLOAD_BEFORE, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_BEFORE"))
+      .withColumn(PAYLOAD_AFTER, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_AFTER"))
+      .withColumn(PAYLOAD_SOURCE, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_SOURCE"))
+      .withColumn(TS_MS, get_json_object($"$PAYLOAD_SOURCE", f"$$.$PAYLOAD_SOURCE_TS_MS").cast(LongType))
+      .withColumn(DATE_TIME_PARTITION, from_unixtime($"$TS_MS" / 1000L, DATE_HOUR_FORMAT))
+      .select(
+        $"$PAYLOAD_TS_MS",
+        $"$PAYLOAD_OP",
+        $"$PAYLOAD_BEFORE",
+        $"$PAYLOAD_AFTER",
+        $"$PAYLOAD_SOURCE",
+        $"$DATE_TIME_PARTITION"
+      )
+  }
+
+  /**
+   * Transforms a Raw Data Lake DataFrame into a Curated Data Lake format by structuring and flattening data.
+   *
+   * The resulting DataFrame has the following schema:
+   * {{{
+   *   root
+   *    |-- _struct_source: struct (nullable = false)
+   *    |   |-- _ts_ms: long (nullable = false)
+   *    |   |-- _shard_id: string (nullable = false)
+   *    |   |-- _sequence_number: string (nullable = false)
+   *    |-- _struct_data: struct (nullable = false)
+   *    |   |-- id: long (nullable = true)
+   *    |   |-- ...                                 # Other fields inferred from the table schema
+   * }}}
+   *
+   * @param rawLakeDataFrame The input DataFrame formatted for the Raw Data Lake.
+   * @param tableSchema      The schema of the target table, used to infer fields in the 'data' struct.
+   * @return A DataFrame formatted for the Curated Data Lake with structured source and data columns.
+   */
+  def transformToCuratedDataLake(rawLakeDataFrame: DataFrame, tableSchema: StructType): DataFrame = {
+    import rawLakeDataFrame.sparkSession.implicits._
+
+    rawLakeDataFrame
+      .withColumn(STRUCT_SOURCE, struct(extractedSourceColumns: _*))
+      .withColumn(JSON_DATA, when($"$PAYLOAD_OP" === PAYLOAD_OP_D, $"$PAYLOAD_BEFORE").otherwise($"$PAYLOAD_AFTER"))
+      .withColumn(STRUCT_DATA, struct(buildStructColumns(tableSchema): _*))
+  }
+
+  /**
+   * Constructs an array of Columns for the structured 'data' field based on the table schema.
+   *
+   * @param tableSchema The target table schema, defining the fields to be extracted from JSON data.
+   * @return An array of Columns with values extracted and cast according to the schema.
+   */
+  private def buildStructColumns(tableSchema: StructType): Array[Column] = {
+    tableSchema.fields.map { field =>
+      get_json_object(col(JSON_DATA), f"$$.${field.name}").cast(field.dataType).as(field.name)
+    }
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataLakeMongoDbTransformer.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataLakeMongoDbTransformer.scala
@@ -1,0 +1,176 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.github.davidch93.etl.core.constants.MetadataField._
+import com.github.davidch93.etl.core.utils.JsonUtils
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{LongType, StringType, StructType}
+import org.apache.spark.sql.{Column, DataFrame}
+
+/**
+ * Object responsible for transforming MongoDB data ingested from Kafka into two formats:
+ *  - Raw Data Lake format
+ *  - Curated Data Lake format
+ *
+ * This transformation extracts necessary fields, applies schema structures, and formats data
+ * to ensure compatibility for downstream processing.
+ *
+ * @author david.christianto
+ */
+object DataLakeMongoDbTransformer {
+
+  private val extractedSourceColumns = Array(
+    get_json_object(col(PAYLOAD_SOURCE), s"$$.$PAYLOAD_SOURCE_TS_MS").cast(LongType).as(TS_MS),
+    get_json_object(col(PAYLOAD_SOURCE), s"$$.$PAYLOAD_SOURCE_ORD").cast(LongType).as(ORD)
+  )
+
+  /**
+   * Extracts MongoDB payload in the following order
+   *   1. Handle `$set` (MongoDB 3 & 4)
+   *   1. Handle `diff` with `u` and `i` (Mongo 5 or above)
+   *   1. Handle `diff` with `u` only (Mongo 5 or above)
+   *   1. Handle `diff` with `i` only (Mongo 5 or above)
+   *   1. Create an empty JSON with `_id` information only.
+   */
+  private val extractPatchPayloadUDF: UserDefinedFunction = udf((jsonString: String, id: String) => {
+    val payload = JsonUtils.toJsonNode(jsonString)
+    val oid = JsonUtils.toJsonNode(id)
+    if (payload.has(PAYLOAD_SET)) {
+      payload.get(PAYLOAD_SET).asInstanceOf[ObjectNode].set("_id", oid).toString
+    } else if (payload.has(PAYLOAD_DIFF) && payload.get(PAYLOAD_DIFF).has(PAYLOAD_DIFF_U) && payload.get(PAYLOAD_DIFF).has(PAYLOAD_DIFF_I)) {
+      val newPayload = JsonUtils.createEmptyObjectNode()
+      newPayload.setAll(payload.get(PAYLOAD_DIFF).get(PAYLOAD_DIFF_U).asInstanceOf[ObjectNode])
+      newPayload.setAll(payload.get(PAYLOAD_DIFF).get(PAYLOAD_DIFF_I).asInstanceOf[ObjectNode])
+      newPayload.set("_id", oid).toString
+    } else if (payload.has(PAYLOAD_DIFF) && payload.get(PAYLOAD_DIFF).has(PAYLOAD_DIFF_U)) {
+      payload.get(PAYLOAD_DIFF).get(PAYLOAD_DIFF_U).asInstanceOf[ObjectNode].set("_id", oid).toString
+    } else if (payload.has(PAYLOAD_DIFF) && payload.get(PAYLOAD_DIFF).has(PAYLOAD_DIFF_I)) {
+      payload.get(PAYLOAD_DIFF).get(PAYLOAD_DIFF_I).asInstanceOf[ObjectNode].set("_id", oid).toString
+    } else {
+      payload.asInstanceOf[ObjectNode].set("_id", oid).toString
+    }
+  })
+
+  /**
+   * Extracts the payload for delete (`d`) events, creating an empty JSON object with `_id` only.
+   */
+  private val extractDeletedPayloadUDF: UserDefinedFunction = udf((jsonString: String) => {
+    val oid = JsonUtils.toJsonNode(jsonString)
+    JsonUtils.createEmptyObjectNode().set("_id", oid).toString
+  })
+
+  /**
+   * Transforms a Kafka DataFrame containing MongoDB change events into a Raw Data Lake format.
+   *
+   * The resulting DataFrame has the following schema:
+   * {{{
+   *   root
+   *    |-- ts_ms: long (nullable = false)
+   *    |-- op: string (nullable = false)
+   *    |-- before: string (nullable = true)
+   *    |-- after: string (nullable = true)
+   *    |-- source: string (nullable = false)
+   *    |-- _datetime_partition: string (nullable = false)
+   * }}}
+   *
+   * @param kafkaDataFrame The input DataFrame containing MongoDB CDC events in JSON format from Kafka.
+   * @return A DataFrame with fields extracted and formatted for the Raw Data Lake.
+   */
+  def transformToRawDataLake(kafkaDataFrame: DataFrame): DataFrame = {
+    import kafkaDataFrame.sparkSession.implicits._
+
+    kafkaDataFrame
+      .withColumn("_id", get_json_object($"$KEY", f"$$.$PAYLOAD.$PAYLOAD_ID"))
+      .withColumn(PAYLOAD_TS_MS, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_TS_MS").cast(LongType))
+      .withColumn(PAYLOAD_OP, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_OP"))
+      .withColumn(PAYLOAD_BEFORE, lit(null).cast(StringType))
+      .withColumn(PAYLOAD_AFTER, when($"$PAYLOAD_OP" === PAYLOAD_OP_R || $"$PAYLOAD_OP" === PAYLOAD_OP_C, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_AFTER"))
+        .when($"$PAYLOAD_OP" === PAYLOAD_OP_U, extractPatchPayloadUDF(get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_PATCH"), $"_id"))
+        .when($"$PAYLOAD_OP" === PAYLOAD_OP_D, extractDeletedPayloadUDF($"_id")))
+      .withColumn(PAYLOAD_SOURCE, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_SOURCE"))
+      .withColumn(TS_MS, get_json_object($"$PAYLOAD_SOURCE", s"$$.$PAYLOAD_SOURCE_TS_MS").cast(LongType))
+      .withColumn(DATE_TIME_PARTITION, from_unixtime($"$TS_MS" / 1000L, DATE_HOUR_FORMAT))
+      .select(
+        $"$PAYLOAD_TS_MS",
+        $"$PAYLOAD_OP",
+        $"$PAYLOAD_BEFORE",
+        $"$PAYLOAD_AFTER",
+        $"$PAYLOAD_SOURCE",
+        $"$DATE_TIME_PARTITION"
+      )
+  }
+
+  /**
+   * Transforms a Raw Data Lake DataFrame into a Curated Data Lake format by structuring and flattening data.
+   *
+   * The resulting DataFrame has the following schema:
+   * {{{
+   *   root
+   *    |-- _struct_source: struct (nullable = false)
+   *    |   |-- _ts_ms: long (nullable = false)
+   *    |   |-- _ord: long (nullable = false)
+   *    |-- _struct_data: struct (nullable = false)
+   *    |   |-- id: long (nullable = true)
+   *    |   |-- ...                                 # Other fields inferred from the table schema
+   * }}}
+   *
+   * @param rawLakeDataFrame The input DataFrame formatted for the Raw Data Lake.
+   * @param tableSchema      The schema of the target table, used to infer fields in the 'data' struct.
+   * @return A DataFrame formatted for the Curated Data Lake with structured source and data columns.
+   */
+  def transformToCuratedDataLake(rawLakeDataFrame: DataFrame, tableSchema: StructType): DataFrame = {
+    rawLakeDataFrame
+      .withColumn(STRUCT_SOURCE, struct(extractedSourceColumns: _*))
+      .withColumn(STRUCT_DATA, struct(buildStructColumns(tableSchema): _*))
+  }
+
+  /**
+   * Constructs an array of Columns for the structured 'data' field based on the table schema.
+   *
+   * For example: Input
+   * {{{
+   *   {
+   *     "id": "{\"$oid\":\"630b23db6ef80123d6e72d74\"}",
+   *     "name": "data",
+   *     "member_id": {
+   *       "$numberLong": 123456789
+   *     },
+   *     "created_at": {
+   *       "$date": 1662085428734
+   *     },
+   *     "updated_at": {
+   *       "$date": "1662085428734"
+   *     }
+   *   }
+   * }}}
+   *
+   * Output
+   * {{{
+   *   {
+   *     "id": "{\"$oid\":\"630b23db6ef80123d6e72d74\"}",
+   *     "name": "data",
+   *     "member_id": 123456789
+   *     "created_at": 1662085428734
+   *     "updated_at": 1662085428734
+   *   }
+   * }}}
+   *
+   * @param tableSchema The target table schema, defining the fields to be extracted from JSON data.
+   * @return An array of Columns with values extracted and cast according to the schema.
+   */
+  private def buildStructColumns(tableSchema: StructType): Array[Column] = {
+    tableSchema.fields.map { field =>
+      val column = get_json_object(col(PAYLOAD_AFTER), f"$$.${field.name}")
+      when(column.isNull, null).otherwise(
+        coalesce(
+          get_json_object(column, "$.$date"),
+          get_json_object(column, "$.$numberInt"),
+          get_json_object(column, "$.$numberLong"),
+          get_json_object(column, "$.$numberDecimal"),
+          column
+        ).cast(field.dataType)
+      ).as(field.name)
+    }
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataLakeMySqlTransformer.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataLakeMySqlTransformer.scala
@@ -1,0 +1,103 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.constants.MetadataField._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{LongType, StructType}
+import org.apache.spark.sql.{Column, DataFrame}
+
+/**
+ * Object responsible for transforming MySQL data ingested from Kafka into two formats:
+ *  - Raw Data Lake format
+ *  - Curated Data Lake format
+ *
+ * This transformation extracts necessary fields, applies schema structures, and formats data
+ * to ensure compatibility for downstream processing.
+ *
+ * @author david.christianto
+ */
+object DataLakeMySqlTransformer {
+
+  private val extractedSourceColumns = Array(
+    get_json_object(col(PAYLOAD_SOURCE), s"$$.$PAYLOAD_SOURCE_TS_MS").cast(LongType).as(TS_MS),
+    get_json_object(col(PAYLOAD_SOURCE), s"$$.$PAYLOAD_SOURCE_FILE").as(FILE),
+    get_json_object(col(PAYLOAD_SOURCE), s"$$.$PAYLOAD_SOURCE_POS").cast(LongType).as(POS)
+  )
+
+  /**
+   * Transforms a Kafka DataFrame containing MySQL change events into a Raw Data Lake format.
+   *
+   * The resulting DataFrame has the following schema:
+   * {{{
+   *   root
+   *    |-- ts_ms: long (nullable = false)
+   *    |-- op: string (nullable = false)
+   *    |-- before: string (nullable = true)
+   *    |-- after: string (nullable = true)
+   *    |-- source: string (nullable = false)
+   *    |-- _datetime_partition: string (nullable = false)
+   * }}}
+   *
+   * @param kafkaDataFrame The input DataFrame containing MySQL CDC events in JSON format from Kafka.
+   * @return A DataFrame with fields extracted and formatted for the Raw Data Lake.
+   */
+  def transformToRawDataLake(kafkaDataFrame: DataFrame): DataFrame = {
+    import kafkaDataFrame.sparkSession.implicits._
+
+    kafkaDataFrame
+      .withColumn(PAYLOAD_TS_MS, get_json_object($"$VALUE", s"$$.$PAYLOAD.$PAYLOAD_TS_MS").cast(LongType))
+      .withColumn(PAYLOAD_OP, get_json_object($"$VALUE", s"$$.$PAYLOAD.$PAYLOAD_OP"))
+      .withColumn(PAYLOAD_BEFORE, get_json_object($"$VALUE", s"$$.$PAYLOAD.$PAYLOAD_BEFORE"))
+      .withColumn(PAYLOAD_AFTER, get_json_object($"$VALUE", s"$$.$PAYLOAD.$PAYLOAD_AFTER"))
+      .withColumn(PAYLOAD_SOURCE, get_json_object($"$VALUE", s"$$.$PAYLOAD.$PAYLOAD_SOURCE"))
+      .withColumn(TS_MS, get_json_object($"$PAYLOAD_SOURCE", s"$$.$PAYLOAD_SOURCE_TS_MS").cast(LongType))
+      .withColumn(DATE_TIME_PARTITION, from_unixtime($"$TS_MS" / 1000L, DATE_HOUR_FORMAT))
+      .select(
+        $"$PAYLOAD_TS_MS",
+        $"$PAYLOAD_OP",
+        $"$PAYLOAD_BEFORE",
+        $"$PAYLOAD_AFTER",
+        $"$PAYLOAD_SOURCE",
+        $"$DATE_TIME_PARTITION"
+      )
+  }
+
+  /**
+   * Transforms a Raw Data Lake DataFrame into a Curated Data Lake format by structuring and flattening data.
+   *
+   * The resulting DataFrame has the following schema:
+   * {{{
+   *   root
+   *    |-- _struct_source: struct (nullable = false)
+   *    |   |-- _ts_ms: long (nullable = false)
+   *    |   |-- _file: string (nullable = false)
+   *    |   |-- _pos: long (nullable = false)
+   *    |-- _struct_data: struct (nullable = false)
+   *    |   |-- id: long (nullable = true)
+   *    |   |-- ...                                 # Other fields inferred from the table schema
+   * }}}
+   *
+   * @param rawLakeDataFrame The input DataFrame formatted for the Raw Data Lake.
+   * @param tableSchema      The schema of the target table, used to infer fields in the 'data' struct.
+   * @return A DataFrame formatted for the Curated Data Lake with structured source and data columns.
+   */
+  def transformToCuratedDataLake(rawLakeDataFrame: DataFrame, tableSchema: StructType): DataFrame = {
+    import rawLakeDataFrame.sparkSession.implicits._
+
+    rawLakeDataFrame
+      .withColumn(STRUCT_SOURCE, struct(extractedSourceColumns: _*))
+      .withColumn(JSON_DATA, when($"$PAYLOAD_OP" === PAYLOAD_OP_D, $"$PAYLOAD_BEFORE").otherwise($"$PAYLOAD_AFTER"))
+      .withColumn(STRUCT_DATA, struct(buildStructColumns(tableSchema): _*))
+  }
+
+  /**
+   * Constructs an array of Columns for the structured 'data' field based on the table schema.
+   *
+   * @param tableSchema The target table schema, defining the fields to be extracted from JSON data.
+   * @return An array of Columns with values extracted and cast according to the schema.
+   */
+  private def buildStructColumns(tableSchema: StructType): Array[Column] = {
+    tableSchema.fields.map { field =>
+      get_json_object(col(JSON_DATA), f"$$.${field.name}").cast(field.dataType).as(field.name)
+    }
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataLakePostgreSqlTransformer.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataLakePostgreSqlTransformer.scala
@@ -1,0 +1,99 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.constants.MetadataField._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{LongType, StringType, StructType}
+import org.apache.spark.sql.{Column, DataFrame}
+
+/**
+ * Object responsible for transforming PostgreSQL data ingested from Kafka into two formats:
+ *  - Raw Data Lake format
+ *  - Curated Data Lake format
+ *
+ * This transformation extracts necessary fields, applies schema structures, and formats data
+ * to ensure compatibility for downstream processing.
+ *
+ * @author david.christianto
+ */
+object DataLakePostgreSqlTransformer {
+
+  private val extractedSourceColumns = Array(
+    get_json_object(col(PAYLOAD_SOURCE), f"$$.$PAYLOAD_SOURCE_TS_MS").cast(LongType).as(TS_MS),
+    get_json_object(col(PAYLOAD_SOURCE), f"$$.$PAYLOAD_SOURCE_LSN").cast(LongType).as(LSN)
+  )
+
+  /**
+   * Transforms a Kafka DataFrame containing PostgreSQL change events into a Raw Data Lake format.
+   *
+   * The resulting DataFrame has the following schema:
+   * {{{
+   *   root
+   *    |-- ts_ms: long (nullable = false)
+   *    |-- op: string (nullable = false)
+   *    |-- before: string (nullable = true)
+   *    |-- after: string (nullable = true)
+   *    |-- source: string (nullable = false)
+   *    |-- _datetime_partition: string (nullable = false)
+   * }}}
+   *
+   * @param kafkaDataFrame The input DataFrame containing PostgreSQL CDC events in JSON format from Kafka.
+   * @return A DataFrame with fields extracted and formatted for the Raw Data Lake.
+   */
+  def transformToRawDataLake(kafkaDataFrame: DataFrame): DataFrame = {
+    import kafkaDataFrame.sparkSession.implicits._
+
+    kafkaDataFrame
+      .withColumn(PAYLOAD_TS_MS, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_TS_MS").cast(LongType))
+      .withColumn(PAYLOAD_OP, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_OP"))
+      .withColumn(PAYLOAD_BEFORE, lit(null).cast(StringType))
+      .withColumn(PAYLOAD_AFTER, when($"$PAYLOAD_OP" === PAYLOAD_OP_D, $"$KEY")
+        .otherwise(get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_AFTER")))
+      .withColumn(PAYLOAD_SOURCE, get_json_object($"$VALUE", f"$$.$PAYLOAD.$PAYLOAD_SOURCE"))
+      .withColumn(TS_MS, get_json_object($"$PAYLOAD_SOURCE", f"$$.$PAYLOAD_SOURCE_TS_MS").cast(LongType))
+      .withColumn(DATE_TIME_PARTITION, from_unixtime($"$TS_MS" / 1000L, DATE_HOUR_FORMAT))
+      .select(
+        $"$PAYLOAD_TS_MS",
+        $"$PAYLOAD_OP",
+        $"$PAYLOAD_BEFORE",
+        $"$PAYLOAD_AFTER",
+        $"$PAYLOAD_SOURCE",
+        $"$DATE_TIME_PARTITION"
+      )
+  }
+
+  /**
+   * Transforms a Raw Data Lake DataFrame into a Curated Data Lake format by structuring and flattening data.
+   *
+   * The resulting DataFrame has the following schema:
+   * {{{
+   *   root
+   *    |-- _struct_source: struct (nullable = false)
+   *    |   |-- _ts_ms: long (nullable = false)
+   *    |   |-- _lsn: string (nullable = false)
+   *    |-- _struct_data: struct (nullable = false)
+   *    |   |-- id: long (nullable = true)
+   *    |   |-- ...                                 # Other fields inferred from the table schema
+   * }}}
+   *
+   * @param rawLakeDataFrame The input DataFrame formatted for the Raw Data Lake.
+   * @param tableSchema      The schema of the target table, used to infer fields in the 'data' struct.
+   * @return A DataFrame formatted for the Curated Data Lake with structured source and data columns.
+   */
+  def transformToCuratedDataLake(rawLakeDataFrame: DataFrame, tableSchema: StructType): DataFrame = {
+    rawLakeDataFrame
+      .withColumn(STRUCT_SOURCE, struct(extractedSourceColumns: _*))
+      .withColumn(STRUCT_DATA, struct(buildStructColumns(tableSchema): _*))
+  }
+
+  /**
+   * Constructs an array of Columns for the structured 'data' field based on the table schema.
+   *
+   * @param tableSchema The target table schema, defining the fields to be extracted from JSON data.
+   * @return An array of Columns with values extracted and cast according to the schema.
+   */
+  private def buildStructColumns(tableSchema: StructType): Array[Column] = {
+    tableSchema.fields.map { field =>
+      get_json_object(col(PAYLOAD_AFTER), f"$$.${field.name}").cast(field.dataType).as(field.name)
+    }
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/Kafka.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/Kafka.scala
@@ -1,0 +1,296 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.batch.helpers.SchemaConverter
+import com.github.davidch93.etl.batch.writers.GcsWriter
+import com.github.davidch93.etl.core.constants.MetadataField._
+import com.github.davidch93.etl.core.constants.Source
+import com.github.davidch93.etl.core.schema.Table
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.time.{LocalDateTime, ZoneOffset}
+
+/**
+ * A transformer class for reading data from Kafka, transforming it, and
+ * writing it to a Data Lake in raw and curated formats.
+ *
+ * Scala example to load Kafka data with a specific time range:
+ * {{{
+ *   Kafka
+ *     .read(kafkaTopic)
+ *     .withKafkaBootstrapServers(kafkaBootstrapServers)
+ *     .withTimeRange(startTimestamp, endTimestamp)
+ *     .withTable(tableSchema)
+ *     .withDataLakePath(dataLakePath)
+ *     .loadAndWriteDataLake()
+ * }}}
+ *
+ * @param spark                 The active `SparkSession`.
+ * @param kafkaTopic            The Kafka topic to subscribe to.
+ * @param kafkaBootstrapServers The Kafka bootstrap servers for reading messages.
+ * @param startTimestamp        The start timestamp for consuming messages from Kafka.
+ * @param endTimestamp          The end timestamp for consuming messages from Kafka.
+ * @param table                 The table metadata, including partitioning information.
+ * @param dataLakePath          The target path in the Data Lake for storing the output.
+ * @author david.christianto
+ */
+class Kafka private(
+  spark: SparkSession,
+  kafkaTopic: String,
+  kafkaBootstrapServers: String,
+  startTimestamp: LocalDateTime,
+  endTimestamp: LocalDateTime,
+  table: Table,
+  dataLakePath: String,
+) {
+
+  import spark.implicits._
+
+  private val transformToRawDataLake: DataFrame => DataFrame = kafkaDataFrame => {
+    table.getSource match {
+      case Source.MYSQL => DataLakeMySqlTransformer.transformToRawDataLake(kafkaDataFrame)
+      case Source.POSTGRESQL => DataLakePostgreSqlTransformer.transformToRawDataLake(kafkaDataFrame)
+      case Source.MONGODB => DataLakeMongoDbTransformer.transformToRawDataLake(kafkaDataFrame)
+      case Source.DYNAMODB => DataLakeDynamoDbTransformer.transformToRawDataLake(kafkaDataFrame)
+    }
+  }
+
+  private val transformToCuratedDataLake: DataFrame => DataFrame = rawLakeDataFrame => {
+    val schema = SchemaConverter.tableSchemaToStructType(table.getSchema)
+    table.getSource match {
+      case Source.MYSQL => DataLakeMySqlTransformer.transformToCuratedDataLake(rawLakeDataFrame, schema)
+      case Source.POSTGRESQL => DataLakePostgreSqlTransformer.transformToCuratedDataLake(rawLakeDataFrame, schema)
+      case Source.MONGODB => DataLakeMongoDbTransformer.transformToCuratedDataLake(rawLakeDataFrame, schema)
+      case Source.DYNAMODB => DataLakeDynamoDbTransformer.transformToCuratedDataLake(rawLakeDataFrame, schema)
+    }
+  }
+
+  /**
+   * Loads data from Kafka, applies transformations, and writes the raw and curated data to the Data Lake.
+   *
+   * Returns a tuple containing the raw and curated DataFrames.
+   *
+   * The first `DataFrame` is a cached raw data lake with the following schema
+   * {{{
+   *   root
+   *    |-- ts_ms: long (nullable = false)
+   *    |-- op: string (nullable = false)
+   *    |-- before: string (nullable = true)
+   *    |-- after: string (nullable = true)
+   *    |-- source: string (nullable = false)
+   *    |-- _datetime_partition: string (nullable = false)
+   * }}}
+   *
+   * The second `Dataframe` is a curated data lake with the following schema.
+   * {{{
+   *   root
+   *    |-- id: long (nullable = true)
+   *    |-- ...                                           # The other fields
+   *    |-- order_timestamp: timestamp (nullable = true)  # A partition field if any
+   *    |-- _is_deleted: boolean (nullable = false)
+   *    |-- _audit_write_time: long (nullable = false)
+   *    |-- _ts_ms: long (nullable = false)
+   *    |-- _file: string (nullable = false)
+   *    |-- _pos: long (nullable = false)
+   * }}}
+   *
+   * @param isTesting If `true`, skips the write operation and uses the provided test `DataFrame`.
+   * @param testingDF An optional `DataFrame` for testing purposes.
+   * @return A tuple containing the raw and curated DataFrames.
+   */
+  private def loadAndWriteDataLake(isTesting: Boolean, testingDF: Option[DataFrame]): (DataFrame, DataFrame) = {
+    val rawLakeDataFrame = testingDF.getOrElse(readFromKafka())
+      .transform(transformToRawDataLake)
+      .repartition($"$DATE_TIME_PARTITION")
+      .cache()
+
+    if (!isTesting) {
+      GcsWriter.writeAppend(rawLakeDataFrame)
+        .withGcsPath(dataLakePath)
+        .withPartitions(Array(DATE_TIME_PARTITION))
+        .execute()
+    }
+
+    val curatedLakeDataFrame = transformToCuratedDataLake(rawLakeDataFrame)
+      .withColumn(IS_DELETED, when($"$PAYLOAD_OP" === PAYLOAD_OP_D, true).otherwise(false))
+      .transform(addPartitionColumn)
+
+    (rawLakeDataFrame, curatedLakeDataFrame)
+  }
+
+  /**
+   * Reads data from Kafka as a `DataFrame` based on the configured settings.
+   *
+   * Connects to Kafka using the specified bootstrap servers and topic. It reads messages
+   * based on the provided starting and ending timestamps and casts the key and value to strings.
+   *
+   * The `startingOffsetsByTimestampStrategy` option will be used when the specified starting offset
+   * by timestamp (either global or per partition) doesn't match with the offset Kafka returned.
+   *  - "error": fail the query and end users have to deal with workarounds requiring manual steps.
+   *  - "latest": assigns the latest offset for these partitions, so that Spark can read newer records
+   *    from these partitions in further micro-batches.
+   *
+   * @return A `DataFrame` containing messages read from Kafka.
+   */
+  private def readFromKafka(): DataFrame = {
+    spark
+      .read
+      .format("org.apache.spark.sql.kafka010.KafkaSourceProvider")
+      .option("kafka.bootstrap.servers", kafkaBootstrapServers)
+      .option("subscribe", kafkaTopic)
+      .option("startingTimestamp", startTimestamp.toInstant(ZoneOffset.UTC).toEpochMilli)
+      .option("endingTimestamp", endTimestamp.toInstant(ZoneOffset.UTC).toEpochMilli)
+      .option("startingOffsetsByTimestampStrategy", "latest")
+      .load()
+      .select($"$KEY".cast(StringType), $"$VALUE".cast(StringType))
+  }
+
+  /**
+   * Adds a partition column to the `DataFrame` based on the table's partitioning configuration.
+   *
+   * @param curatedLakeDataFrame The curated data lake `DataFrame`.
+   * @return The `DataFrame` with the added partition column if any.
+   */
+  private def addPartitionColumn(curatedLakeDataFrame: DataFrame): DataFrame = {
+    val tablePartitionOpt = Option(table.getTablePartition.orElse(null))
+
+    tablePartitionOpt match {
+      case Some(tablePartition) =>
+        val sourceColumn = tablePartition.getSourceColumn
+        val partitionColumn = tablePartition.getPartitionColumn
+        val timestampColumn = to_timestamp(from_unixtime($"$STRUCT_DATA.$sourceColumn" / 1000))
+
+        curatedLakeDataFrame
+          .withColumn(partitionColumn, timestampColumn)
+          .select(
+            $"$STRUCT_DATA.*",
+            $"$partitionColumn",
+            $"$IS_DELETED",
+            $"$STRUCT_SOURCE.*"
+          )
+
+      case None =>
+        curatedLakeDataFrame
+          .select(
+            $"$STRUCT_DATA.*",
+            $"$IS_DELETED",
+            $"$STRUCT_SOURCE.*",
+          )
+    }
+  }
+}
+
+/**
+ * Companion object for creating and configuring instances of the `Kafka` class.
+ *
+ * @author david.christianto
+ */
+object Kafka {
+
+  /**
+   * Initializes a Kafka builder using the active `SparkSession`.
+   *
+   * @param kafkaTopic The Kafka topic to read from.
+   * @return A `KafkaBuilder` instance for further configuration.
+   */
+  def read(kafkaTopic: String): KafkaBuilder = {
+    val spark = SparkSession.getActiveSession.getOrElse {
+      throw new IllegalArgumentException("Could not find active SparkSession")
+    }
+    read(spark, kafkaTopic)
+  }
+
+  /**
+   * Initializes a Kafka builder with the specified `SparkSession` and topic.
+   *
+   * @param spark      The `SparkSession` to use.
+   * @param kafkaTopic The Kafka topic to read from.
+   * @return A `KafkaBuilder` instance for further configuration.
+   */
+  def read(spark: SparkSession, kafkaTopic: String): KafkaBuilder = {
+    KafkaBuilder(spark, kafkaTopic)
+  }
+
+  /**
+   * A builder class for configuring Kafka-based ETL operations.
+   *
+   * @param spark                 The `SparkSession` instance.
+   * @param kafkaTopic            The Kafka topic to read from.
+   * @param kafkaBootstrapServers The Kafka bootstrap servers.
+   * @param startTimestamp        The start timestamp for consuming messages.
+   * @param endTimestamp          The end timestamp for consuming messages.
+   * @param table                 The table metadata.
+   * @param dataLakePath          The Data Lake path for storing the output.
+   */
+  case class KafkaBuilder private(
+    private val spark: SparkSession,
+    private val kafkaTopic: String,
+    private val kafkaBootstrapServers: String = null,
+    private val startTimestamp: LocalDateTime = null,
+    private val endTimestamp: LocalDateTime = null,
+    private val table: Table = null,
+    private val dataLakePath: String = null
+  ) {
+
+    /**
+     * Specifies the Kafka bootstrap servers to use for connecting to Kafka.
+     *
+     * @param kafkaBootstrapServers The Kafka bootstrap servers.
+     * @return An updated `KafkaBuilder` instance.
+     */
+    def withKafkaBootstrapServers(kafkaBootstrapServers: String): KafkaBuilder =
+      copy(kafkaBootstrapServers = kafkaBootstrapServers)
+
+    /**
+     * Specifies the time range for consuming messages from Kafka.
+     *
+     * @param startTimestamp The start timestamp for consuming messages.
+     * @param endTimestamp   The end timestamp for consuming messages.
+     * @return An updated `KafkaBuilder` instance.
+     */
+    def withTimeRange(startTimestamp: LocalDateTime, endTimestamp: LocalDateTime): KafkaBuilder =
+      copy(startTimestamp = startTimestamp).copy(endTimestamp = endTimestamp)
+
+    /**
+     * Specifies the table metadata, including partitioning information.
+     *
+     * @param table The table metadata.
+     * @return An updated `KafkaBuilder` instance.
+     */
+    def withTable(table: Table): KafkaBuilder =
+      copy(table = table)
+
+    /**
+     * Specifies the Data Lake path for storing the output data.
+     *
+     * @param dataLakePath The Data Lake path.
+     * @return An updated `KafkaBuilder` instance.
+     */
+    def withDataLakePath(dataLakePath: String): KafkaBuilder =
+      copy(dataLakePath = dataLakePath)
+
+    /**
+     * Executes the ETL process by loading data from Kafka, transforming it, and writing it to the Data Lake.
+     *
+     * @param isTesting Optional boolean flag indicating whether to run in a testing environment. Defaults to `false`.
+     *                  If `true`, skips the write operation and uses the provided test `DataFrame`.
+     * @param testingDF Optional `DataFrame` used for testing when `isTesting` is `true`.
+     *                  Provides mock data for testing purposes.
+     * @return A tuple containing the raw and curated DataFrames.
+     */
+    def loadAndWriteDataLake(
+      isTesting: Boolean = false,
+      testingDF: Option[DataFrame] = None
+    ): (DataFrame, DataFrame) =
+      new Kafka(
+        spark,
+        kafkaTopic,
+        kafkaBootstrapServers,
+        startTimestamp,
+        endTimestamp,
+        table,
+        dataLakePath
+      ).loadAndWriteDataLake(isTesting, testingDF)
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/writers/GcsWriter.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/writers/GcsWriter.scala
@@ -1,0 +1,103 @@
+package com.github.davidch93.etl.batch.writers
+
+import org.apache.spark.sql.{DataFrame, SaveMode}
+
+/**
+ * A utility class for writing a DataFrame to Google Cloud Storage (GCS) in Parquet format.
+ * The class supports optional partitioning of the data based on specified columns.
+ *
+ * Scala example to write DataFrame to GCS:
+ * {{{
+ *   GcsWriter.writeAppend(df)
+ *     .withGcsPath(gcsPath)
+ *     .withPartitions(Array(partitions))
+ *     .execute()
+ * }}}
+ *
+ * @param dataFrame  The input DataFrame to be written to GCS.
+ * @param gcsPath    The target GCS path where the data will be stored.
+ * @param partitions An array of column names used for partitioning the data.
+ *                   If empty or `null`, no partitioning is applied.
+ * @author david.christianto
+ */
+class GcsWriter(dataFrame: DataFrame, gcsPath: String, partitions: Array[String]) {
+
+  /**
+   * Executes the write operation to GCS.
+   *
+   *  - If partitions are specified, the data is written in partitioned Parquet format.
+   *  - If no partitions are specified, the data is written as a single Parquet file.
+   */
+  def execute(): Unit = {
+    if (partitions.nonEmpty) {
+      dataFrame
+        .write
+        .mode(SaveMode.Append)
+        .partitionBy(partitions: _*)
+        .parquet(gcsPath)
+    } else {
+      dataFrame
+        .write
+        .mode(SaveMode.Append)
+        .parquet(gcsPath)
+    }
+  }
+}
+
+/**
+ * Companion object for the `GcsWriter` class, providing a builder pattern to simplify
+ * the creation and configuration of a `GcsWriter` instance.
+ *
+ * @author david.christianto
+ */
+object GcsWriter {
+
+  /**
+   * Initializes a builder for writing a DataFrame to GCS in append mode.
+   *
+   * @param dataFrame The input DataFrame to be written.
+   * @return An instance of `GcsWriterBuilder` for further configuration.
+   */
+  def writeAppend(dataFrame: DataFrame): GcsWriterBuilder = {
+    GcsWriterBuilder(dataFrame)
+  }
+
+  /**
+   * A builder class for configuring and executing GCS write operations.
+   *
+   * @param dataFrame  The DataFrame to be written.
+   * @param gcsPath    The target GCS path for storing the data.
+   * @param partitions An array of column names used for partitioning the data.
+   */
+  case class GcsWriterBuilder private(
+    dataFrame: DataFrame,
+    gcsPath: String = "",
+    partitions: Array[String] = Array()
+  ) {
+
+    /**
+     * Sets the GCS path for the write operation.
+     *
+     * @param gcsPath The target GCS path.
+     * @return A new instance of `GcsWriterBuilder` with the updated GCS path.
+     */
+    def withGcsPath(gcsPath: String): GcsWriterBuilder =
+      copy(gcsPath = gcsPath)
+
+    /**
+     * Sets the columns for partitioning the data.
+     *
+     * @param partitions An array of column names used for partitioning.
+     * @return A new instance of `GcsWriterBuilder` with the updated partition columns.
+     */
+    def withPartitions(partitions: Array[String]): GcsWriterBuilder =
+      copy(partitions = partitions)
+
+    /**
+     * Executes the configured GCS write operation.
+     */
+    def execute(): Unit = {
+      new GcsWriter(dataFrame, gcsPath, partitions).execute()
+    }
+  }
+}

--- a/etl-batch/src/test/resources/kafka/dynamodb/github_staging_transactions.json
+++ b/etl-batch/src/test/resources/kafka/dynamodb/github_staging_transactions.json
@@ -1,0 +1,14 @@
+[
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"c\",\"ts_ms\":\"1733813344632\",\"before\":null,\"after\":{\"id\":2,\"user_id\":2,\"order_id\":2,\"notes\":null,\"created_at\":1733813319170,\"updated_at\":1733813319170},\"source\":{\"version\":\"1.0.0\",\"connector\":\"DYNAMODB\",\"ts_ms\":\"1733813319670\",\"name\":\"dynamodbstaging\",\"db\":\"github_staging\",\"table\":\"transactions\",\"shard_id\":\"shardId-00000001696411483678-f3df68e4\",\"sequence_number\":\"600000000019036501898\"}}}"
+  },
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"u\",\"ts_ms\":\"1733813345632\",\"before\":{\"id\":2,\"user_id\":2,\"order_id\":2,\"notes\":\"\",\"created_at\":1733813319170,\"updated_at\":1733813319170},\"after\":{\"id\":2,\"user_id\":2,\"order_id\":2,\"notes\":\"example\",\"created_at\":1733813319170,\"updated_at\":1733813320170},\"source\":{\"version\":\"1.0.0\",\"connector\":\"DYNAMODB\",\"ts_ms\":\"1733813320670\",\"name\":\"dynamodbstaging\",\"db\":\"github_staging\",\"table\":\"transactions\",\"shard_id\":\"shardId-00000001696411483678-f3df68e4\",\"sequence_number\":\"600000000019036501899\"}}}"
+  },
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"d\",\"ts_ms\":\"1733813346632\",\"before\":{\"id\":2,\"user_id\":2,\"order_id\":2,\"notes\":\"example\",\"created_at\":1733813319170,\"updated_at\":1733813320170},\"after\":null,\"source\":{\"version\":\"1.0.0\",\"connector\":\"DYNAMODB\",\"ts_ms\":\"1733813321670\",\"name\":\"dynamodbstaging\",\"db\":\"github_staging\",\"table\":\"transactions\",\"shard_id\":\"shardId-00000001696411483678-f3df68e4\",\"sequence_number\":\"600000000019036501900\"}}}"
+  }
+]

--- a/etl-batch/src/test/resources/kafka/mongodb/github_staging_transactions.json
+++ b/etl-batch/src/test/resources/kafka/mongodb/github_staging_transactions.json
@@ -1,0 +1,30 @@
+[
+  {
+    "key": "{\"payload\":{\"id\":\"{\\\"$oid\\\":\\\"630b23db6ef80123d6e72d74\\\"}\"}}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"c\",\"ts_ms\":1733813344632,\"before\":null,\"after\":\"{\\\"_id\\\":{\\\"$oid\\\":\\\"630b23db6ef80123d6e72d74\\\"},\\\"user_id\\\":{\\\"$numberInt\\\":2},\\\"order_id\\\":{\\\"$numberLong\\\":2},\\\"fee\\\":{\\\"$numberDecimal\\\":\\\"12345.6789\\\"},\\\"created_at\\\":{\\\"$date\\\":1733813319170},\\\"updated_at\\\":{\\\"$date\\\":1733813319170}}\",\"source\":{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813319670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":31}}}"
+  },
+  {
+    "key": "{\"payload\":{\"id\":\"{\\\"$oid\\\":\\\"630b23db6ef80123d6e72d74\\\"}\"}}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"u\",\"ts_ms\":1733813345632,\"before\":null,\"patch\":\"{\\\"$set\\\":{\\\"fee\\\":{\\\"$numberDecimal\\\":\\\"12345.67891\\\"},\\\"updated_at\\\":{\\\"$date\\\":1733813320170}}}\",\"source\":{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813320670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":32}}}"
+  },
+  {
+    "key": "{\"payload\":{\"id\":\"{\\\"$oid\\\":\\\"630b23db6ef80123d6e72d74\\\"}\"}}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"u\",\"ts_ms\":1733813346632,\"before\":null,\"patch\":\"{\\\"fee\\\":{\\\"$numberDecimal\\\":\\\"12345.67892\\\"},\\\"updated_at\\\":{\\\"$date\\\":1733813321170}}\",\"source\":{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813321670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":33}}}"
+  },
+  {
+    "key": "{\"payload\":{\"id\":\"{\\\"$oid\\\":\\\"630b23db6ef80123d6e72d74\\\"}\"}}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"u\",\"ts_ms\":1733813347632,\"before\":null,\"patch\":\"{\\\"v\\\":2,\\\"diff\\\":{\\\"i\\\":{\\\"notes\\\":\\\"example\\\"}}}\",\"source\":{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813322670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":34}}}"
+  },
+  {
+    "key": "{\"payload\":{\"id\":\"{\\\"$oid\\\":\\\"630b23db6ef80123d6e72d74\\\"}\"}}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"u\",\"ts_ms\":1733813348632,\"before\":null,\"patch\":\"{\\\"v\\\":2,\\\"diff\\\":{\\\"u\\\":{\\\"updated_at\\\":{\\\"$date\\\":1733813322170}}}}\",\"source\":{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813323670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":35}}}"
+  },
+  {
+    "key": "{\"payload\":{\"id\":\"{\\\"$oid\\\":\\\"630b23db6ef80123d6e72d74\\\"}\"}}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"u\",\"ts_ms\":1733813349632,\"before\":null,\"patch\":\"{\\\"v\\\":2,\\\"diff\\\":{\\\"u\\\":{\\\"updated_at\\\":{\\\"$date\\\":1733813323170}},\\\"i\\\":{\\\"notes\\\":{\\\"user\\\":\\\"data\\\",\\\"status\\\":\\\"PAID\\\"}}}}\",\"source\":{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813324670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":36}}}"
+  },
+  {
+    "key": "{\"payload\":{\"id\":\"{\\\"$oid\\\":\\\"630b23db6ef80123d6e72d74\\\"}\"}}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"d\",\"ts_ms\":1733813350632,\"before\":null,\"after\":null,\"source\":{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813325670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":37}}}"
+  }
+]

--- a/etl-batch/src/test/resources/kafka/mysql/github_staging_orders.json
+++ b/etl-batch/src/test/resources/kafka/mysql/github_staging_orders.json
@@ -1,0 +1,14 @@
+[
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"c\",\"ts_ms\":1733813344632,\"before\":null,\"after\":{\"id\":2,\"amount\":150000,\"status\":\"PAID\",\"is_expired\":false,\"created_at\":1733813319170},\"source\":{\"version\":\"1.0.0\",\"connector\":\"MYSQL\",\"ts_ms\":1733813319670,\"name\":\"mysqlstaging\",\"db\":\"github_staging\",\"table\":\"orders\",\"server_id\":20241210,\"gtid\":\"50791c3f-66ae-ee15-4e7a-70668ea778de:14981727984\",\"file\":\"binlog-0001\",\"pos\":4,\"xid\":728530626}}}"
+  },
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"u\",\"ts_ms\":1733813345632,\"before\":{\"id\":2,\"amount\":150000,\"status\":\"PAID\",\"is_expired\":false,\"created_at\":1733813319170},\"after\":{\"id\":2,\"amount\":150000,\"status\":\"PAID\",\"is_expired\":true,\"created_at\":1733813319170},\"source\":{\"version\":\"1.0.0\",\"connector\":\"MYSQL\",\"ts_ms\":1733813320670,\"name\":\"mysqlstaging\",\"db\":\"github_staging\",\"table\":\"orders\",\"server_id\":20241210,\"gtid\":\"50791c3f-66ae-ee15-4e7a-70668ea778de:14981727985\",\"file\":\"binlog-0001\",\"pos\":5,\"xid\":728530627}}}"
+  },
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"d\",\"ts_ms\":1733813346632,\"before\":{\"id\":2,\"amount\":150000,\"status\":\"PAID\",\"is_expired\":true,\"created_at\":1733813319170},\"after\":null,\"source\":{\"version\":\"1.0.0\",\"connector\":\"MYSQL\",\"ts_ms\":1733813321670,\"name\":\"mysqlstaging\",\"db\":\"github_staging\",\"table\":\"orders\",\"server_id\":20241210,\"gtid\":\"50791c3f-66ae-ee15-4e7a-70668ea778de:14981727986\",\"file\":\"binlog-0001\",\"pos\":6,\"xid\":728530628}}}"
+  }
+]

--- a/etl-batch/src/test/resources/kafka/postgresql/github_staging_users.json
+++ b/etl-batch/src/test/resources/kafka/postgresql/github_staging_users.json
@@ -1,0 +1,14 @@
+[
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"c\",\"ts_ms\":1733813344632,\"before\":null,\"after\":{\"id\":2,\"email\":\"user@example.com\",\"created_at\":1733813319170,\"updated_at\":1733813319170},\"source\":{\"version\":\"1.0.0\",\"connector\":\"POSTGRESQL\",\"ts_ms\":1733813319670,\"name\":\"postgresqlstaging\",\"db\":\"github_staging\",\"schema\":\"public\",\"table\":\"users\",\"lsn\":24023128,\"txid\":728530626}}}"
+  },
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"u\",\"ts_ms\":1733813345632,\"before\":null,\"after\":{\"id\":2,\"email\":\"user-updated@example.com\",\"created_at\":1733813319170,\"updated_at\":1733813320170},\"source\":{\"version\":\"1.0.0\",\"connector\":\"POSTGRESQL\",\"ts_ms\":1733813320670,\"name\":\"postgresqlstaging\",\"db\":\"github_staging\",\"schema\":\"public\",\"table\":\"users\",\"lsn\":24023129,\"txid\":728530627}}}"
+  },
+  {
+    "key": "{\"id\":2}",
+    "value": "{\"schema\":[],\"payload\":{\"op\":\"d\",\"ts_ms\":1733813346632,\"before\":null,\"after\":null,\"source\":{\"version\":\"1.0.0\",\"connector\":\"POSTGRESQL\",\"ts_ms\":1733813321670,\"name\":\"postgresqlstaging\",\"db\":\"github_staging\",\"schema\":\"public\",\"table\":\"users\",\"lsn\":24023130,\"txid\":728530628}}}"
+  }
+]

--- a/etl-batch/src/test/resources/schema/dynamodb/github_staging_transactions/schema.json
+++ b/etl-batch/src/test/resources/schema/dynamodb/github_staging_transactions/schema.json
@@ -1,0 +1,58 @@
+{
+  "table_name": "github_staging_transactions",
+  "source_type": "DYNAMODB",
+  "schema": {
+    "type": "record",
+    "name": "transactions",
+    "doc": "Schema for the transactions table",
+    "fields": [
+      {
+        "name": "id",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "Unique identifier for the transaction",
+        "rules": [
+          {
+            "rule": "IS_PRIMARY_KEY",
+            "hint": "The value of this column must be unique and not NULL!"
+          }
+        ]
+      },
+      {
+        "name": "user_id",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "The id corresponding to the user table"
+      },
+      {
+        "name": "order_id",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "The id corresponding to the order table"
+      },
+      {
+        "name": "notes",
+        "type": "STRING",
+        "nullable": true,
+        "doc": "The transaction notes"
+      },
+      {
+        "name": "created_at",
+        "type": "INTEGER",
+        "nullable": true,
+        "doc": "Date of the order was created"
+      },
+      {
+        "name": "updated_at",
+        "type": "INTEGER",
+        "nullable": true,
+        "doc": "Date of the order was updated"
+      }
+    ]
+  },
+  "constraint_keys": [
+    "id",
+    "user_id",
+    "order_id"
+  ]
+}

--- a/etl-batch/src/test/resources/schema/mongodb/github_staging_transactions/schema.json
+++ b/etl-batch/src/test/resources/schema/mongodb/github_staging_transactions/schema.json
@@ -1,0 +1,64 @@
+{
+  "table_name": "github_staging_transactions",
+  "source_type": "MONGODB",
+  "schema": {
+    "type": "record",
+    "name": "transactions",
+    "doc": "Schema for the transactions table",
+    "fields": [
+      {
+        "name": "_id",
+        "type": "STRING",
+        "nullable": false,
+        "doc": "Unique identifier for the transaction",
+        "rules": [
+          {
+            "rule": "IS_PRIMARY_KEY",
+            "hint": "The value of this column must be unique and not NULL!"
+          }
+        ]
+      },
+      {
+        "name": "user_id",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "The id corresponding to the user table"
+      },
+      {
+        "name": "order_id",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "The id corresponding to the order table"
+      },
+      {
+        "name": "fee",
+        "type": "DOUBLE",
+        "nullable": true,
+        "doc": "The transaction fee"
+      },
+      {
+        "name": "notes",
+        "type": "STRING",
+        "nullable": true,
+        "doc": "The transaction notes"
+      },
+      {
+        "name": "created_at",
+        "type": "INTEGER",
+        "nullable": true,
+        "doc": "Date of the order was created"
+      },
+      {
+        "name": "updated_at",
+        "type": "INTEGER",
+        "nullable": true,
+        "doc": "Date of the order was updated"
+      }
+    ]
+  },
+  "constraint_keys": [
+    "_id",
+    "user_id",
+    "order_id"
+  ]
+}

--- a/etl-batch/src/test/resources/schema/mysql/github_staging_orders/schema.json
+++ b/etl-batch/src/test/resources/schema/mysql/github_staging_orders/schema.json
@@ -1,0 +1,88 @@
+{
+  "table_name": "github_staging_orders",
+  "source_type": "MYSQL",
+  "schema": {
+    "type": "record",
+    "name": "orders",
+    "doc": "Schema for the orders table",
+    "fields": [
+      {
+        "name": "id",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "Unique identifier for the order",
+        "rules": [
+          {
+            "rule": "IS_PRIMARY_KEY",
+            "hint": "The value of this column must be unique and not NULL!"
+          }
+        ]
+      },
+      {
+        "name": "amount",
+        "type": "DOUBLE",
+        "nullable": true,
+        "doc": "Total amount of the order",
+        "rules": [
+          {
+            "rule": "IS_NON_NEGATIVE",
+            "hint": "The value of this column must be positive!"
+          },
+          {
+            "rule": "HAS_COMPLETENESS",
+            "assertion": "0.85",
+            "hint": "NULL values of this column should be below 0.15!"
+          }
+        ]
+      },
+      {
+        "name": "status",
+        "type": "STRING",
+        "nullable": true,
+        "doc": "Status of the order",
+        "rules": [
+          {
+            "rule": "IS_CONTAINED_IN",
+            "values": [
+              "PAID",
+              "CANCELLED",
+              "REMITTED"
+            ],
+            "hint": "The value of this column must contain PAID, CANCELLED, and REMITTED only"
+          }
+        ]
+      },
+      {
+        "name": "is_expired",
+        "type": "BOOLEAN",
+        "nullable": true,
+        "doc": "Whether the order expires or not"
+      },
+      {
+        "name": "created_at",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "Date of the order",
+        "rules": [
+          {
+            "rule": "IS_COMPLETE",
+            "hint": "The value of this column must not be NULL!"
+          }
+        ]
+      }
+    ]
+  },
+  "constraint_keys": [
+    "id"
+  ],
+  "table_partition": {
+    "source_column": "created_at",
+    "partition_column": "order_timestamp",
+    "partition_type": "DAY",
+    "partition_filter_required": false,
+    "doc": "A partition column indicating the date of the order was created"
+  },
+  "clustered_columns": [
+    "id"
+  ]
+}

--- a/etl-batch/src/test/resources/schema/postgresql/github_staging_users/schema.json
+++ b/etl-batch/src/test/resources/schema/postgresql/github_staging_users/schema.json
@@ -1,0 +1,50 @@
+{
+  "table_name": "github_staging_users",
+  "source_type": "POSTGRESQL",
+  "schema": {
+    "type": "record",
+    "name": "users",
+    "doc": "Schema for the users table",
+    "fields": [
+      {
+        "name": "id",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "Unique identifier for the user",
+        "rules": [
+          {
+            "rule": "IS_PRIMARY_KEY",
+            "hint": "The value of this column must be unique and not NULL!"
+          }
+        ]
+      },
+      {
+        "name": "email",
+        "type": "STRING",
+        "nullable": false,
+        "doc": "The email address corresponding to the user",
+        "rules": [
+          {
+            "rule": "IS_UNIQUE",
+            "hint": "The value of this column must be unique!"
+          }
+        ]
+      },
+      {
+        "name": "created_at",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "Date of the order was created"
+      },
+      {
+        "name": "updated_at",
+        "type": "INTEGER",
+        "nullable": false,
+        "doc": "Date of the order was updated"
+      }
+    ]
+  },
+  "constraint_keys": [
+    "id"
+  ]
+}

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/helpers/SchemaConverterTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/helpers/SchemaConverterTest.scala
@@ -1,0 +1,75 @@
+package com.github.davidch93.etl.batch.helpers
+
+import com.github.davidch93.etl.core.constants.MetadataField.IS_DELETED
+import com.github.davidch93.etl.core.schema.SchemaLoader
+import org.apache.spark.sql.types._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class SchemaConverterTest extends AnyFunSuite with Matchers {
+
+  test("Converting to StructType should convert a valid TableSchema to StructType") {
+    val schemaFilePath = "src/test/resources/schema/mysql/github_staging_orders/schema.json"
+    val table = SchemaLoader.loadTableSchema(schemaFilePath)
+
+    val expectedSchema = StructType(
+      Array(
+        StructField("id", LongType, nullable = false),
+        StructField("amount", DoubleType, nullable = true),
+        StructField("status", StringType, nullable = true),
+        StructField("is_expired", BooleanType, nullable = true),
+        StructField("created_at", LongType, nullable = false),
+      )
+    )
+
+    val result = SchemaConverter.tableSchemaToStructType(table.getSchema)
+    result shouldEqual expectedSchema
+  }
+
+  test("Converting to StructType should IllegalArgumentException when a table schema is null") {
+    intercept[IllegalArgumentException] {
+      SchemaConverter.tableSchemaToStructType(null)
+    }.getMessage should include("The table schema cannot be null!")
+  }
+
+  test("Converting to StructType should add IS_DELETED column if tablePartition is None") {
+    val schemaFilePath = "src/test/resources/schema/mysql/github_staging_orders/schema.json"
+    val table = SchemaLoader.loadTableSchema(schemaFilePath)
+
+    val expectedSchema = StructType(
+      Array(
+        StructField("id", LongType, nullable = false),
+        StructField("amount", DoubleType, nullable = true),
+        StructField("status", StringType, nullable = true),
+        StructField("is_expired", BooleanType, nullable = true),
+        StructField("created_at", LongType, nullable = false),
+        StructField(IS_DELETED, BooleanType, nullable = false),
+      )
+    )
+
+    val result = SchemaConverter.tableSchemaWithMetadataToStructType(table.getSchema)
+    result shouldEqual expectedSchema
+  }
+
+  test("Converting to StructType should add partition and IS_DELETED columns if tablePartition is present") {
+    val schemaFilePath = "src/test/resources/schema/mysql/github_staging_orders/schema.json"
+    val table = SchemaLoader.loadTableSchema(schemaFilePath)
+
+    val expectedSchema = StructType(
+      Array(
+        StructField("id", LongType, nullable = false),
+        StructField("amount", DoubleType, nullable = true),
+        StructField("status", StringType, nullable = true),
+        StructField("is_expired", BooleanType, nullable = true),
+        StructField("created_at", LongType, nullable = false),
+        StructField("order_timestamp", TimestampType, nullable = false),
+        StructField(IS_DELETED, BooleanType, nullable = false),
+      )
+    )
+
+    val tablePartitionOpt = Option(table.getTablePartition.orElse(null))
+    val result = SchemaConverter.tableSchemaWithMetadataToStructType(table.getSchema, tablePartitionOpt)
+
+    result shouldEqual expectedSchema
+  }
+}

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataLakeDynamoDbTransformerTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataLakeDynamoDbTransformerTest.scala
@@ -1,0 +1,52 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.schema.SchemaLoader
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDateTime
+
+class DataLakeDynamoDbTransformerTest extends AnyFunSuite with Matchers {
+
+  test("Loading Kafka DynamoDB data should return a valid Data Lake") {
+    val spark = SparkSession.builder().master("local[1]").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    val kafkaTopic = "dynamodbstaging.github_staging.transactions"
+    val kafkaBootstrapServers = "localhost:9092"
+    val startScheduledTimestamp = LocalDateTime.parse("2024-12-19T17:00:00")
+    val endScheduledTimestamp = LocalDateTime.parse("2024-12-20T17:00:00")
+    val dataLakePath = "build/tmp"
+
+    val schemaFilePath = "src/test/resources/schema/dynamodb/github_staging_transactions/schema.json"
+    val tableSchema = SchemaLoader.loadTableSchema(schemaFilePath)
+
+    val jsonFile = "src/test/resources/kafka/dynamodb/github_staging_transactions.json"
+    val testingDataFrame = spark.read.option("multiline", "true").json(jsonFile)
+
+    val (rawLakeDataFrame, curatedLakeDataFrame) = Kafka
+      .read(kafkaTopic)
+      .withKafkaBootstrapServers(kafkaBootstrapServers)
+      .withTimeRange(startScheduledTimestamp, endScheduledTimestamp)
+      .withTable(tableSchema)
+      .withDataLakePath(dataLakePath)
+      .loadAndWriteDataLake(isTesting = true, Some(testingDataFrame))
+
+    val expectedRawLakeDataFrame = Array(
+      Row(1733813344632L, "c", null, "{\"id\":2,\"user_id\":2,\"order_id\":2,\"notes\":null,\"created_at\":1733813319170,\"updated_at\":1733813319170}", "{\"version\":\"1.0.0\",\"connector\":\"DYNAMODB\",\"ts_ms\":\"1733813319670\",\"name\":\"dynamodbstaging\",\"db\":\"github_staging\",\"table\":\"transactions\",\"shard_id\":\"shardId-00000001696411483678-f3df68e4\",\"sequence_number\":\"600000000019036501898\"}", "2024-12-10T13:00:00"),
+      Row(1733813345632L, "u", "{\"id\":2,\"user_id\":2,\"order_id\":2,\"notes\":\"\",\"created_at\":1733813319170,\"updated_at\":1733813319170}", "{\"id\":2,\"user_id\":2,\"order_id\":2,\"notes\":\"example\",\"created_at\":1733813319170,\"updated_at\":1733813320170}", "{\"version\":\"1.0.0\",\"connector\":\"DYNAMODB\",\"ts_ms\":\"1733813320670\",\"name\":\"dynamodbstaging\",\"db\":\"github_staging\",\"table\":\"transactions\",\"shard_id\":\"shardId-00000001696411483678-f3df68e4\",\"sequence_number\":\"600000000019036501899\"}", "2024-12-10T13:00:00"),
+      Row(1733813346632L, "d", "{\"id\":2,\"user_id\":2,\"order_id\":2,\"notes\":\"example\",\"created_at\":1733813319170,\"updated_at\":1733813320170}", null, "{\"version\":\"1.0.0\",\"connector\":\"DYNAMODB\",\"ts_ms\":\"1733813321670\",\"name\":\"dynamodbstaging\",\"db\":\"github_staging\",\"table\":\"transactions\",\"shard_id\":\"shardId-00000001696411483678-f3df68e4\",\"sequence_number\":\"600000000019036501900\"}", "2024-12-10T13:00:00")
+    )
+
+    rawLakeDataFrame.collect() should contain theSameElementsAs expectedRawLakeDataFrame
+
+    val expectedCuratedLakeDataFrame = Array(
+      Row(2L, 2L, 2L, null, 1733813319170L, 1733813319170L, false, 1733813319670L, "shardId-00000001696411483678-f3df68e4", "600000000019036501898"),
+      Row(2L, 2L, 2L, "example", 1733813319170L, 1733813320170L, false, 1733813320670L, "shardId-00000001696411483678-f3df68e4", "600000000019036501899"),
+      Row(2L, 2L, 2L, "example", 1733813319170L, 1733813320170L, true, 1733813321670L, "shardId-00000001696411483678-f3df68e4", "600000000019036501900"),
+    )
+
+    curatedLakeDataFrame.collect() should contain theSameElementsAs expectedCuratedLakeDataFrame
+  }
+}

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataLakeMongoDbTransformerTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataLakeMongoDbTransformerTest.scala
@@ -1,0 +1,60 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.schema.SchemaLoader
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDateTime
+
+class DataLakeMongoDbTransformerTest extends AnyFunSuite with Matchers {
+
+  test("Loading Kafka MongoDB data should return a valid Data Lake") {
+    val spark = SparkSession.builder().master("local[1]").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    val kafkaTopic = "mongodbstaging.github_staging.transactions"
+    val kafkaBootstrapServers = "localhost:9092"
+    val startScheduledTimestamp = LocalDateTime.parse("2024-12-19T17:00:00")
+    val endScheduledTimestamp = LocalDateTime.parse("2024-12-20T17:00:00")
+    val dataLakePath = "build/tmp"
+
+    val schemaFilePath = "src/test/resources/schema/mongodb/github_staging_transactions/schema.json"
+    val tableSchema = SchemaLoader.loadTableSchema(schemaFilePath)
+
+    val jsonFile = "src/test/resources/kafka/mongodb/github_staging_transactions.json"
+    val testingDataFrame = spark.read.option("multiline", "true").json(jsonFile)
+
+    val (rawLakeDataFrame, curatedLakeDataFrame) = Kafka
+      .read(kafkaTopic)
+      .withKafkaBootstrapServers(kafkaBootstrapServers)
+      .withTimeRange(startScheduledTimestamp, endScheduledTimestamp)
+      .withTable(tableSchema)
+      .withDataLakePath(dataLakePath)
+      .loadAndWriteDataLake(isTesting = true, Some(testingDataFrame))
+
+    val expectedRawLakeDataFrame = Array(
+      Row(1733813344632L, "c", null, "{\"_id\":{\"$oid\":\"630b23db6ef80123d6e72d74\"},\"user_id\":{\"$numberInt\":2},\"order_id\":{\"$numberLong\":2},\"fee\":{\"$numberDecimal\":\"12345.6789\"},\"created_at\":{\"$date\":1733813319170},\"updated_at\":{\"$date\":1733813319170}}", "{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813319670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":31}", "2024-12-10T13:00:00"),
+      Row(1733813345632L, "u", null, "{\"fee\":{\"$numberDecimal\":\"12345.67891\"},\"updated_at\":{\"$date\":1733813320170},\"_id\":{\"$oid\":\"630b23db6ef80123d6e72d74\"}}", "{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813320670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":32}", "2024-12-10T13:00:00"),
+      Row(1733813346632L, "u", null, "{\"fee\":{\"$numberDecimal\":\"12345.67892\"},\"updated_at\":{\"$date\":1733813321170},\"_id\":{\"$oid\":\"630b23db6ef80123d6e72d74\"}}", "{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813321670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":33}", "2024-12-10T13:00:00"),
+      Row(1733813347632L, "u", null, "{\"notes\":\"example\",\"_id\":{\"$oid\":\"630b23db6ef80123d6e72d74\"}}", "{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813322670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":34}", "2024-12-10T13:00:00"),
+      Row(1733813348632L, "u", null, "{\"updated_at\":{\"$date\":1733813322170},\"_id\":{\"$oid\":\"630b23db6ef80123d6e72d74\"}}", "{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813323670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":35}", "2024-12-10T13:00:00"),
+      Row(1733813349632L, "u", null, "{\"updated_at\":{\"$date\":1733813323170},\"notes\":{\"user\":\"data\",\"status\":\"PAID\"},\"_id\":{\"$oid\":\"630b23db6ef80123d6e72d74\"}}", "{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813324670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":36}", "2024-12-10T13:00:00"),
+      Row(1733813350632L, "d", null, "{\"_id\":{\"$oid\":\"630b23db6ef80123d6e72d74\"}}", "{\"version\":\"1.0.0\",\"connector\":\"MONGODB\",\"ts_ms\":1733813325670,\"name\":\"mongodbstaging\",\"db\":\"github_staging\",\"collection\":\"transactions\",\"ord\":37}", "2024-12-10T13:00:00")
+    )
+
+    rawLakeDataFrame.collect() should contain theSameElementsAs expectedRawLakeDataFrame
+
+    val expectedCuratedLakeDataFrame = Array(
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d74\"}", 2L, 2L, 12345.6789, null, 1733813319170L, 1733813319170L, false, 1733813319670L, 31L),
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d74\"}", null, null, 12345.67891, null, null, 1733813320170L, false, 1733813320670L, 32L),
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d74\"}", null, null, 12345.67892, null, null, 1733813321170L, false, 1733813321670L, 33L),
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d74\"}", null, null, null, "example", null, null, false, 1733813322670L, 34L),
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d74\"}", null, null, null, null, null, 1733813322170L, false, 1733813323670L, 35L),
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d74\"}", null, null, null, "{\"user\":\"data\",\"status\":\"PAID\"}", null, 1733813323170L, false, 1733813324670L, 36L),
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d74\"}", null, null, null, null, null, null, true, 1733813325670L, 37L),
+    )
+
+    curatedLakeDataFrame.collect() should contain theSameElementsAs expectedCuratedLakeDataFrame
+  }
+}

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataLakeMySqlTransformerTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataLakeMySqlTransformerTest.scala
@@ -1,0 +1,53 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.schema.SchemaLoader
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+class DataLakeMySqlTransformerTest extends AnyFunSuite with Matchers {
+
+  test("Loading Kafka MySQL data with a partition column should return a valid Data Lake") {
+    val spark = SparkSession.builder().master("local[1]").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    val kafkaTopic = "mysqlstaging.github_staging.orders"
+    val kafkaBootstrapServers = "localhost:9092"
+    val startScheduledTimestamp = LocalDateTime.parse("2024-12-19T17:00:00")
+    val endScheduledTimestamp = LocalDateTime.parse("2024-12-20T17:00:00")
+    val dataLakePath = "build/tmp"
+
+    val schemaFilePath = "src/test/resources/schema/mysql/github_staging_orders/schema.json"
+    val tableSchema = SchemaLoader.loadTableSchema(schemaFilePath)
+
+    val jsonFile = "src/test/resources/kafka/mysql/github_staging_orders.json"
+    val testingDataFrame = spark.read.option("multiline", "true").json(jsonFile)
+
+    val (rawLakeDataFrame, curatedLakeDataFrame) = Kafka
+      .read(kafkaTopic)
+      .withKafkaBootstrapServers(kafkaBootstrapServers)
+      .withTimeRange(startScheduledTimestamp, endScheduledTimestamp)
+      .withTable(tableSchema)
+      .withDataLakePath(dataLakePath)
+      .loadAndWriteDataLake(isTesting = true, Some(testingDataFrame))
+
+    val expectedRawLakeDataFrame = Array(
+      Row(1733813344632L, "c", null, "{\"id\":2,\"amount\":150000,\"status\":\"PAID\",\"is_expired\":false,\"created_at\":1733813319170}", "{\"version\":\"1.0.0\",\"connector\":\"MYSQL\",\"ts_ms\":1733813319670,\"name\":\"mysqlstaging\",\"db\":\"github_staging\",\"table\":\"orders\",\"server_id\":20241210,\"gtid\":\"50791c3f-66ae-ee15-4e7a-70668ea778de:14981727984\",\"file\":\"binlog-0001\",\"pos\":4,\"xid\":728530626}", "2024-12-10T13:00:00"),
+      Row(1733813345632L, "u", "{\"id\":2,\"amount\":150000,\"status\":\"PAID\",\"is_expired\":false,\"created_at\":1733813319170}", "{\"id\":2,\"amount\":150000,\"status\":\"PAID\",\"is_expired\":true,\"created_at\":1733813319170}", "{\"version\":\"1.0.0\",\"connector\":\"MYSQL\",\"ts_ms\":1733813320670,\"name\":\"mysqlstaging\",\"db\":\"github_staging\",\"table\":\"orders\",\"server_id\":20241210,\"gtid\":\"50791c3f-66ae-ee15-4e7a-70668ea778de:14981727985\",\"file\":\"binlog-0001\",\"pos\":5,\"xid\":728530627}", "2024-12-10T13:00:00"),
+      Row(1733813346632L, "d", "{\"id\":2,\"amount\":150000,\"status\":\"PAID\",\"is_expired\":true,\"created_at\":1733813319170}", null, "{\"version\":\"1.0.0\",\"connector\":\"MYSQL\",\"ts_ms\":1733813321670,\"name\":\"mysqlstaging\",\"db\":\"github_staging\",\"table\":\"orders\",\"server_id\":20241210,\"gtid\":\"50791c3f-66ae-ee15-4e7a-70668ea778de:14981727986\",\"file\":\"binlog-0001\",\"pos\":6,\"xid\":728530628}", "2024-12-10T13:00:00")
+    )
+
+    rawLakeDataFrame.collect() should contain theSameElementsAs expectedRawLakeDataFrame
+
+    val expectedCuratedLakeDataFrame = Array(
+      Row(2L, 150000.0, "PAID", false, 1733813319170L, new Timestamp(1733813319000L), false, 1733813319670L, "binlog-0001", 4L),
+      Row(2L, 150000.0, "PAID", true, 1733813319170L, new Timestamp(1733813319000L), false, 1733813320670L, "binlog-0001", 5L),
+      Row(2L, 150000.0, "PAID", true, 1733813319170L, new Timestamp(1733813319000L), true, 1733813321670L, "binlog-0001", 6L),
+    )
+
+    curatedLakeDataFrame.collect() should contain theSameElementsAs expectedCuratedLakeDataFrame
+  }
+}

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataLakePostgreSqlTransformerTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataLakePostgreSqlTransformerTest.scala
@@ -1,0 +1,52 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.schema.SchemaLoader
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDateTime
+
+class DataLakePostgreSqlTransformerTest extends AnyFunSuite with Matchers {
+
+  test("Loading Kafka PostgreSQL data should return a valid Data Lake") {
+    val spark = SparkSession.builder().master("local[1]").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    val kafkaTopic = "postgresqlstaging.github_staging.users"
+    val kafkaBootstrapServers = "localhost:9092"
+    val startScheduledTimestamp = LocalDateTime.parse("2024-12-19T17:00:00")
+    val endScheduledTimestamp = LocalDateTime.parse("2024-12-20T17:00:00")
+    val dataLakePath = "build/tmp"
+
+    val schemaFilePath = "src/test/resources/schema/postgresql/github_staging_users/schema.json"
+    val tableSchema = SchemaLoader.loadTableSchema(schemaFilePath)
+
+    val jsonFile = "src/test/resources/kafka/postgresql/github_staging_users.json"
+    val testingDataFrame = spark.read.option("multiline", "true").json(jsonFile)
+
+    val (rawLakeDataFrame, curatedLakeDataFrame) = Kafka
+      .read(kafkaTopic)
+      .withKafkaBootstrapServers(kafkaBootstrapServers)
+      .withTimeRange(startScheduledTimestamp, endScheduledTimestamp)
+      .withTable(tableSchema)
+      .withDataLakePath(dataLakePath)
+      .loadAndWriteDataLake(isTesting = true, Some(testingDataFrame))
+
+    val expectedRawLakeDataFrame = Array(
+      Row(1733813344632L, "c", null, "{\"id\":2,\"email\":\"user@example.com\",\"created_at\":1733813319170,\"updated_at\":1733813319170}", "{\"version\":\"1.0.0\",\"connector\":\"POSTGRESQL\",\"ts_ms\":1733813319670,\"name\":\"postgresqlstaging\",\"db\":\"github_staging\",\"schema\":\"public\",\"table\":\"users\",\"lsn\":24023128,\"txid\":728530626}", "2024-12-10T13:00:00"),
+      Row(1733813345632L, "u", null, "{\"id\":2,\"email\":\"user-updated@example.com\",\"created_at\":1733813319170,\"updated_at\":1733813320170}", "{\"version\":\"1.0.0\",\"connector\":\"POSTGRESQL\",\"ts_ms\":1733813320670,\"name\":\"postgresqlstaging\",\"db\":\"github_staging\",\"schema\":\"public\",\"table\":\"users\",\"lsn\":24023129,\"txid\":728530627}", "2024-12-10T13:00:00"),
+      Row(1733813346632L, "d", null, "{\"id\":2}", "{\"version\":\"1.0.0\",\"connector\":\"POSTGRESQL\",\"ts_ms\":1733813321670,\"name\":\"postgresqlstaging\",\"db\":\"github_staging\",\"schema\":\"public\",\"table\":\"users\",\"lsn\":24023130,\"txid\":728530628}", "2024-12-10T13:00:00")
+    )
+
+    rawLakeDataFrame.collect() should contain theSameElementsAs expectedRawLakeDataFrame
+
+    val expectedCuratedLakeDataFrame = Array(
+      Row(2L, "user@example.com", 1733813319170L, 1733813319170L, false, 1733813319670L, 24023128L),
+      Row(2L, "user-updated@example.com", 1733813319170L, 1733813320170L, false, 1733813320670L, 24023129L),
+      Row(2L, null, null, null, true, 1733813321670L, 24023130L),
+    )
+
+    curatedLakeDataFrame.collect() should contain theSameElementsAs expectedCuratedLakeDataFrame
+  }
+}

--- a/etl-core/src/main/java/com/github/davidch93/etl/core/constants/MetadataField.java
+++ b/etl-core/src/main/java/com/github/davidch93/etl/core/constants/MetadataField.java
@@ -29,6 +29,7 @@ public final class MetadataField {
     // Debezium
     public static final String PAYLOAD = "payload";
     public static final String PAYLOAD_ID = "id";
+    public static final String PAYLOAD_TS_MS = "ts_ms";
     public static final String PAYLOAD_OP = "op";
     public static final String PAYLOAD_OP_R = "r";
     public static final String PAYLOAD_OP_C = "c";
@@ -51,16 +52,25 @@ public final class MetadataField {
     public static final String PAYLOAD_SOURCE_SEQUENCE_NUMBER = "sequence_number";
 
     // ETL
+    public static final String STRUCT_SOURCE = "_struct_source";
+    public static final String STRUCT_DATA = "_struct_data";
+    public static final String JSON_DATA = "_json_data";
     public static final String IS_DELETED = "_is_deleted";
     public static final String TABLE_NAME = "_table_name";
     public static final String SOURCE = "_source";
     public static final String OP = "_op";
     public static final String TS_MS = "_ts_ms";
     public static final String TS_PARTITION = "_ts_partition";
+    public static final String DATE_TIME_PARTITION = "_datetime_partition";
     public static final String FILE = "_file";
     public static final String POS = "_pos";
     public static final String ORD = "_ord";
     public static final String LSN = "_lsn";
+    public static final String SHARD_ID = "_shard_id";
+    public static final String SEQUENCE_NUMBER = "_sequence_number";
     public static final String AUDIT_WRITE_TIME = "_audit_write_time";
+
+    // DateTime & Timestamp Format
+    public static final String DATE_HOUR_FORMAT = "yyyy-MM-dd'T'HH:00:00";
     public static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss z";
 }


### PR DESCRIPTION
## Updates
- [x] Added Data Lake transformers in the `etl-batch` module.
  - [x] `DataLakeDynamoDbTransformer`
  - [x] `DataLakeMongoDbTransformer`
  - [x] `DataLakeMySqlTransformer`
  - [x] `DataLakePostgreSqlTransformer`
- [x] Added `GcsWriter` and `SchemaConverter` in the `etl-batch` module.
- [x] Added some new metadata fields for the `etl-batch` module.