### PR TITLE
[20241220] Add Data Pool transformers in the `etl-batch` module

### DIFF
--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPool.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPool.scala
@@ -1,0 +1,163 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.batch.helpers.SchemaConverter
+import com.github.davidch93.etl.core.constants.Source
+import com.github.davidch93.etl.core.schema.Table
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import scala.collection.JavaConverters._
+
+/**
+ * A transformer class for transforming and deduplicating data in a data pool.
+ * It supports metadata column addition, record deduplication, and schema-based loading of data
+ * for various data sources (e.g., MySQL, PostgreSQL, MongoDB, DynamoDB).
+ *
+ * Scala example to get data pool only:
+ * {{{
+ *   DataPool.forPath(dataPoolPath)
+ *     .mergeWith(lakeDataFrame)
+ *     .withTable(tableSchema)
+ *     .load()
+ * }}}
+ *
+ * @param spark         the active `SparkSession`.
+ * @param dataPoolPath  the file path to the data pool (parquet files).
+ * @param lakeDataFrame an optional `DataFrame` representing lake data to merge with the data pool.
+ * @param table         the table schema and metadata defining the structure of the data pool.
+ * @author david.christianto
+ */
+class DataPool private(
+  spark: SparkSession,
+  dataPoolPath: String,
+  lakeDataFrame: DataFrame,
+  table: Table,
+) {
+
+  private val addMetadataColumns: DataFrame => DataFrame = inputDataFrame =>
+    table.getSource match {
+      case Source.MYSQL => DataPoolMySqlTransformer.addMetadataColumns(inputDataFrame)
+      case Source.POSTGRESQL => DataPoolPostgreSqlTransformer.addMetadataColumns(inputDataFrame)
+      case Source.MONGODB => DataPoolMongoDbTransformer.addMetadataColumns(inputDataFrame)
+      case Source.DYNAMODB => DataPoolDynamoDbTransformer.addMetadataColumns(inputDataFrame)
+      case other =>
+        throw new UnsupportedOperationException(s"Unsupported data pool transformation from source: `$other`!")
+    }
+
+  private val deduplicateRecords: (DataFrame, List[String]) => DataFrame = (inputDataFrame, primaryKeys) =>
+    table.getSource match {
+      case Source.MYSQL => DataPoolMySqlTransformer.deduplicateRecords(inputDataFrame, primaryKeys)
+      case Source.POSTGRESQL => DataPoolPostgreSqlTransformer.deduplicateRecords(inputDataFrame, primaryKeys)
+      case Source.MONGODB => DataPoolMongoDbTransformer.deduplicateRecords(inputDataFrame, primaryKeys)
+      case Source.DYNAMODB => DataPoolDynamoDbTransformer.deduplicateRecords(inputDataFrame, primaryKeys)
+      case other =>
+        throw new UnsupportedOperationException(s"Unsupported data pool transformation from source: `$other`!")
+    }
+
+  /**
+   * Loads the data from the data pool, merging it with the lake data if provided.
+   *
+   * Return a DataFrame with the following schema.
+   * {{{
+   *  root
+   *    |-- id: long (nullable = true)
+   *    |-- ...                                            # The other fields
+   *    |-- order_timestamp: timestamp (nullable = false)  # A partition column if any
+   *    |-- _is_deleted: boolean (nullable = false)
+   * }}}
+   *
+   * @return a `DataFrame` representing the loaded and optionally merged data pool.
+   */
+  private def load(): DataFrame = {
+    val tablePartitionOpt = Option(table.getTablePartition.orElse(null))
+    val dataPoolSchema = SchemaConverter.tableSchemaWithMetadataToStructType(table.getSchema, tablePartitionOpt)
+
+    val poolDataFrame = spark
+      .read
+      .schema(dataPoolSchema)
+      .parquet(dataPoolPath)
+
+    if (lakeDataFrame == null || lakeDataFrame.isEmpty) {
+      poolDataFrame
+    } else {
+      val unionDataFrame = lakeDataFrame.union(addMetadataColumns(poolDataFrame))
+      val primaryKeys = table.getConstraintKeys.asScala.toList
+
+      deduplicateRecords(unionDataFrame, primaryKeys)
+    }
+  }
+}
+
+/**
+ * Companion object for creating and configuring a `DataPool` class.
+ *
+ * @author david.christianto
+ */
+object DataPool {
+
+  /**
+   * Creates a `DataPoolBuilder` for the given data pool path using the active `SparkSession`.
+   *
+   * @param dataPoolPath the file path to the data pool (parquet files).
+   * @return a `DataPoolBuilder` instance for further configuration.
+   * @throws IllegalArgumentException if no active `SparkSession` is found.
+   */
+  def forPath(dataPoolPath: String): DataPoolBuilder = {
+    val spark = SparkSession.getActiveSession.getOrElse {
+      throw new IllegalArgumentException("Could not find active SparkSession!")
+    }
+    forPath(spark, dataPoolPath)
+  }
+
+  /**
+   * Creates a `DataPoolBuilder` for the given data pool path and `SparkSession`.
+   *
+   * @param spark        the active `SparkSession`.
+   * @param dataPoolPath the file path to the data pool (parquet files).
+   * @return a `DataPoolBuilder` instance for further configuration.
+   */
+  def forPath(spark: SparkSession, dataPoolPath: String): DataPoolBuilder = {
+    DataPoolBuilder(spark, dataPoolPath)
+  }
+
+  /**
+   * A builder class for configuring and constructing a `DataPool` instance.
+   *
+   * @param spark         the active `SparkSession`.
+   * @param dataPoolPath  the file path to the data pool (parquet files).
+   * @param lakeDataFrame an optional `DataFrame` representing lake data to merge with the data pool.
+   * @param table         the table schema and metadata defining the structure of the data pool.
+   */
+  case class DataPoolBuilder private(
+    private val spark: SparkSession,
+    private val dataPoolPath: String,
+    private val lakeDataFrame: DataFrame = null,
+    private val table: Table = new Table()
+  ) {
+
+    /**
+     * Merges the data pool with the specified lake `DataFrame`.
+     *
+     * @param lakeDataFrame the `DataFrame` to merge with the data pool.
+     * @return a `DataPoolBuilder` with the lake `DataFrame` set.
+     */
+    def mergeWith(lakeDataFrame: DataFrame): DataPoolBuilder =
+      copy(lakeDataFrame = lakeDataFrame)
+
+    /**
+     * Specifies the table schema and metadata for the data pool.
+     *
+     * @param table the `Table` instance defining the schema and metadata.
+     * @return a `DataPoolBuilder` with the table set.
+     */
+    def withTable(table: Table): DataPoolBuilder =
+      copy(table = table)
+
+    /**
+     * Loads the configured data pool, optionally merging it with lake data and deduplicating records.
+     *
+     * @return a `DataFrame` representing the loaded and processed data pool.
+     */
+    def load(): DataFrame =
+      new DataPool(spark, dataPoolPath, lakeDataFrame, table).load()
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPoolDynamoDbTransformer.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPoolDynamoDbTransformer.scala
@@ -1,0 +1,61 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.constants.MetadataField._
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{lit, row_number}
+
+/**
+ * Object responsible for transforming DynamoDB data into a consistent structure for data pooling
+ * and for deduplicating data based on specified constraints.
+ *
+ * @author david.christianto
+ */
+object DataPoolDynamoDbTransformer {
+
+  /**
+   * Adds metadata columns (`TS_MS`, `SHARD_ID`, and `SEQUENCE_NUMBER`) to the given `DataFrame`.
+   *
+   * Return a `DataFrame` with the following schema.
+   * {{{
+   *  root
+   *    |-- id: long (nullable = true)
+   *    |-- ...                              # The other fields based on the table schema
+   *    |-- _ts_ms: long (nullable = false)
+   *    |-- _shard_id: string (nullable = false)
+   *    |-- _sequence_number: string (nullable = false)
+   * }}}
+   *
+   * @param inputDataFrame the input `DataFrame` to be transformed.
+   * @return a `DataFrame` with additional metadata columns.
+   */
+  def addMetadataColumns(inputDataFrame: DataFrame): DataFrame = {
+    inputDataFrame
+      .withColumn(TS_MS, lit(0))
+      .withColumn(SHARD_ID, lit(""))
+      .withColumn(SEQUENCE_NUMBER, lit(""))
+  }
+
+  /**
+   * Deduplicates records in a `DataFrame` based on specified constraint keys.
+   * Retains the latest record for each unique combination of constraint keys,
+   * determined by metadata columns `TS_MS`, `SHARD_ID`, and `SEQUENCE_NUMBER`.
+   *
+   * @param inputDataFrame the `DataFrame` containing records to deduplicate.
+   * @param primaryKeys    the list of primary key column names used for deduplication.
+   * @return a deduplicated `DataFrame` with metadata columns removed.
+   */
+  def deduplicateRecords(inputDataFrame: DataFrame, primaryKeys: List[String]): DataFrame = {
+    import inputDataFrame.sparkSession.implicits._
+
+    val primaryKeysColumns = primaryKeys.map(keys => $"$keys")
+    val window = Window
+      .partitionBy(primaryKeysColumns: _*)
+      .orderBy($"$TS_MS".desc, $"$SHARD_ID".desc, $"$SEQUENCE_NUMBER".desc)
+
+    inputDataFrame
+      .withColumn(ROW_NUMBER, row_number().over(window))
+      .filter($"$ROW_NUMBER" === 1)
+      .drop(ROW_NUMBER, TS_MS, SHARD_ID, SEQUENCE_NUMBER)
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPoolMongoDbTransformer.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPoolMongoDbTransformer.scala
@@ -1,0 +1,71 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.constants.MetadataField._
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{last, lit, row_number}
+
+/**
+ * Object responsible for transforming MongoDB data into a consistent structure for data pooling
+ * and for deduplicating data based on specified constraints.
+ *
+ * @author david.christianto
+ */
+object DataPoolMongoDbTransformer {
+
+  /**
+   * Adds metadata columns (`TS_MS` and `ORD`) to the given `DataFrame`.
+   *
+   * Return a `DataFrame` with the following schema.
+   * {{{
+   *  root
+   *    |-- id: long (nullable = true)
+   *    |-- ...                              # The other fields based on the table schema
+   *    |-- _ts_ms: long (nullable = false)
+   *    |-- _ord: long (nullable = false)
+   * }}}
+   *
+   * @param inputDataFrame the input `DataFrame` to be transformed.
+   * @return a `DataFrame` with additional metadata columns.
+   */
+  def addMetadataColumns(inputDataFrame: DataFrame): DataFrame = {
+    inputDataFrame
+      .withColumn(TS_MS, lit(0))
+      .withColumn(ORD, lit(0))
+  }
+
+  /**
+   * Deduplicates records in a DataFrame based on the specified primary keys.
+   * For duplicate records, retains the latest record for each unique combination of keys.
+   * Aggregates non-key columns to retain their most recent non-null values.
+   *
+   * @param inputDataFrame the DataFrame containing records to deduplicate.
+   * @param primaryKeys    the list of primary key column names used for deduplication.
+   * @return a deduplicated DataFrame with metadata columns removed.
+   */
+  def deduplicateRecords(inputDataFrame: DataFrame, primaryKeys: List[String]): DataFrame = {
+    import inputDataFrame.sparkSession.implicits._
+
+    val primaryKeysColumns = primaryKeys.map(keys => $"$keys")
+
+    val aggregationWindow = Window
+      .partitionBy(primaryKeysColumns: _*)
+      .orderBy($"$TS_MS".asc, $"$ORD".asc)
+
+    val deduplicationWindow = Window
+      .partitionBy(primaryKeysColumns: _*)
+      .orderBy($"$TS_MS".desc, $"$ORD".desc)
+
+    val excludedColumns = primaryKeys ++ TS_MS ++ ORD
+    val aggregatedColumns = inputDataFrame.schema.fieldNames
+      .filterNot(excludedColumns.contains(_))
+      .map(colName => last(colName, ignoreNulls = true).over(aggregationWindow).as(colName))
+
+    val fullColumns = Seq(row_number().over(deduplicationWindow).as(ROW_NUMBER)) ++ primaryKeysColumns ++ aggregatedColumns
+
+    inputDataFrame
+      .select(fullColumns: _*)
+      .filter($"$ROW_NUMBER" === 1)
+      .drop(ROW_NUMBER, TS_MS, ORD)
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPoolMySqlTransformer.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPoolMySqlTransformer.scala
@@ -1,0 +1,61 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.constants.MetadataField._
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{lit, row_number}
+
+/**
+ * Object responsible for transforming MySQL data into a consistent structure for data pooling
+ * and for deduplicating data based on specified constraints.
+ *
+ * @author david.christianto
+ */
+object DataPoolMySqlTransformer {
+
+  /**
+   * Adds metadata columns (`TS_MS`, `FILE`, `POS`) to the given `DataFrame`.
+   *
+   * Return a `DataFrame` with the following schema.
+   * {{{
+   *  root
+   *    |-- id: long (nullable = true)
+   *    |-- ...                              # The other fields based on the table schema
+   *    |-- _ts_ms: long (nullable = false)
+   *    |-- _file: string (nullable = false)
+   *    |-- _pos: long (nullable = false)
+   * }}}
+   *
+   * @param inputDataFrame the input `DataFrame` to be transformed.
+   * @return a `DataFrame` with additional metadata columns.
+   */
+  def addMetadataColumns(inputDataFrame: DataFrame): DataFrame = {
+    inputDataFrame
+      .withColumn(TS_MS, lit(0))
+      .withColumn(FILE, lit(""))
+      .withColumn(POS, lit(0))
+  }
+
+  /**
+   * Deduplicates records in a `DataFrame` based on specified constraint keys.
+   * Retains the latest record for each unique combination of constraint keys,
+   * determined by metadata columns `TS_MS`, `FILE`, and `POS`.
+   *
+   * @param inputDataFrame the `DataFrame` containing records to deduplicate.
+   * @param primaryKeys the list of primary key column names used for deduplication.
+   * @return a deduplicated `DataFrame` with metadata columns removed.
+   */
+  def deduplicateRecords(inputDataFrame: DataFrame, primaryKeys: List[String]): DataFrame = {
+    import inputDataFrame.sparkSession.implicits._
+
+    val primaryKeysColumns = primaryKeys.map(keys => $"$keys")
+    val window = Window
+      .partitionBy(primaryKeysColumns: _*)
+      .orderBy($"$TS_MS".desc, $"$FILE".desc, $"$POS".desc)
+
+    inputDataFrame
+      .withColumn(ROW_NUMBER, row_number().over(window))
+      .filter($"$ROW_NUMBER" === 1)
+      .drop(ROW_NUMBER, TS_MS, FILE, POS)
+  }
+}

--- a/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPoolPostgreSqlTransformer.scala
+++ b/etl-batch/src/main/scala/com/github/davidch93/etl/batch/transformers/DataPoolPostgreSqlTransformer.scala
@@ -1,0 +1,59 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.core.constants.MetadataField._
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{lit, row_number}
+
+/**
+ * Object responsible for transforming PostgreSQL data into a consistent structure for data pooling
+ * and for deduplicating data based on specified constraints.
+ *
+ * @author david.christianto
+ */
+object DataPoolPostgreSqlTransformer {
+
+  /**
+   * Adds metadata columns (`TS_MS` and `LSN`) to the given `DataFrame`.
+   *
+   * Return a `DataFrame` with the following schema.
+   * {{{
+   *  root
+   *    |-- id: long (nullable = true)
+   *    |-- ...                              # The other fields based on the table schema
+   *    |-- _ts_ms: long (nullable = false)
+   *    |-- _lsn: long (nullable = false)
+   * }}}
+   *
+   * @param inputDataFrame the input `DataFrame` to be transformed.
+   * @return a `DataFrame` with additional metadata columns.
+   */
+  def addMetadataColumns(inputDataFrame: DataFrame): DataFrame = {
+    inputDataFrame
+      .withColumn(TS_MS, lit(0))
+      .withColumn(LSN, lit(0))
+  }
+
+  /**
+   * Deduplicates records in a `DataFrame` based on specified constraint keys.
+   * Retains the latest record for each unique combination of constraint keys,
+   * determined by metadata columns `TS_MS` and `LSN`.
+   *
+   * @param inputDataFrame the `DataFrame` containing records to deduplicate.
+   * @param primaryKeys    the list of primary key column names used for deduplication.
+   * @return a deduplicated `DataFrame` with metadata columns removed.
+   */
+  def deduplicateRecords(inputDataFrame: DataFrame, primaryKeys: List[String]): DataFrame = {
+    import inputDataFrame.sparkSession.implicits._
+
+    val primaryKeysColumns = primaryKeys.map(keys => $"$keys")
+    val window = Window
+      .partitionBy(primaryKeysColumns: _*)
+      .orderBy($"$TS_MS".desc, $"$LSN".desc)
+
+    inputDataFrame
+      .withColumn(ROW_NUMBER, row_number().over(window))
+      .filter($"$ROW_NUMBER" === 1)
+      .drop(ROW_NUMBER, TS_MS, LSN)
+  }
+}

--- a/etl-batch/src/test/resources/schema/mongodb/github_staging_transactions/schema.json
+++ b/etl-batch/src/test/resources/schema/mongodb/github_staging_transactions/schema.json
@@ -57,8 +57,6 @@
     ]
   },
   "constraint_keys": [
-    "_id",
-    "user_id",
-    "order_id"
+    "_id"
   ]
 }

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataPoolDynamoDbTransformerTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataPoolDynamoDbTransformerTest.scala
@@ -1,0 +1,82 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.batch.helpers.SchemaConverter
+import com.github.davidch93.etl.core.schema.{SchemaLoader, Table}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDateTime
+
+class DataPoolDynamoDbTransformerTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
+
+  val spark: SparkSession = SparkSession.builder().master("local[1]").getOrCreate()
+
+  val schemaFilePath = "src/test/resources/schema/dynamodb/github_staging_transactions/schema.json"
+  val table: Table = SchemaLoader.loadTableSchema(schemaFilePath)
+
+  val dataPoolPath = "build/tmp/test/dynamodb/github_staging_transactions/snapshot=2024-12-09"
+
+  override def beforeAll(): Unit = {
+    spark.sparkContext.setLogLevel("WARN")
+
+    val tablePartitionOpt = Option(table.getTablePartition.orElse(null))
+    val schemaStruct = SchemaConverter.tableSchemaWithMetadataToStructType(table.getSchema, tablePartitionOpt)
+
+    val rows = Seq(
+      Row(1L, 1L, 1L, null, 1733813310170L, 1733813310170L, false)
+    )
+
+    // Create Data Pool to Filesystem
+    val poolDataFrame = spark.createDataFrame(spark.sparkContext.parallelize(rows), schemaStruct)
+    poolDataFrame
+      .write
+      .mode(SaveMode.Overwrite)
+      .parquet(dataPoolPath)
+  }
+
+  override def afterAll(): Unit = {
+    val path = new Path(dataPoolPath)
+    val fileSystem = path.getFileSystem(new Configuration())
+
+    // Delete Data Pool from Filesystem
+    if (fileSystem.exists(path)) {
+      fileSystem.delete(path, true)
+    }
+  }
+
+  test("Loading and deduplicating DynamoDB data pool should return a valid DataPool") {
+    val kafkaTopic = "dynamodbstaging.github_staging.transactions"
+    val kafkaBootstrapServers = "localhost:9092"
+    val startScheduledTimestamp = LocalDateTime.parse("2024-12-09T17:00:00")
+    val endScheduledTimestamp = LocalDateTime.parse("2024-12-10T17:00:00")
+    val dataLakePath = "build/tmp"
+
+    val jsonFile = "src/test/resources/kafka/dynamodb/github_staging_transactions.json"
+    val testingDataFrame = spark.read.option("multiline", "true").json(jsonFile)
+
+    val (_, curatedLakeDataFrame) = Kafka
+      .read(kafkaTopic)
+      .withKafkaBootstrapServers(kafkaBootstrapServers)
+      .withTimeRange(startScheduledTimestamp, endScheduledTimestamp)
+      .withTable(table)
+      .withDataLakePath(dataLakePath)
+      .loadAndWriteDataLake(isTesting = true, Some(testingDataFrame))
+
+    val poolDataFrame = DataPool
+      .forPath(dataPoolPath)
+      .mergeWith(curatedLakeDataFrame)
+      .withTable(table)
+      .load()
+
+    val expectedPoolDataFrame = Array(
+      Row(1L, 1L, 1L, null, 1733813310170L, 1733813310170L, false),
+      Row(2L, 2L, 2L, "example", 1733813319170L, 1733813320170L, true)
+    )
+
+    poolDataFrame.collect() should contain theSameElementsAs expectedPoolDataFrame
+  }
+}

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataPoolMongoDbTransformerTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataPoolMongoDbTransformerTest.scala
@@ -1,0 +1,82 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.batch.helpers.SchemaConverter
+import com.github.davidch93.etl.core.schema.{SchemaLoader, Table}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDateTime
+
+class DataPoolMongoDbTransformerTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
+
+  val spark: SparkSession = SparkSession.builder().master("local[1]").getOrCreate()
+
+  val schemaFilePath = "src/test/resources/schema/mongodb/github_staging_transactions/schema.json"
+  val table: Table = SchemaLoader.loadTableSchema(schemaFilePath)
+
+  val dataPoolPath = "build/tmp/test/mongodb/github_staging_transactions/snapshot=2024-12-09"
+
+  override def beforeAll(): Unit = {
+    spark.sparkContext.setLogLevel("WARN")
+
+    val tablePartitionOpt = Option(table.getTablePartition.orElse(null))
+    val schemaStruct = SchemaConverter.tableSchemaWithMetadataToStructType(table.getSchema, tablePartitionOpt)
+
+    val rows = Seq(
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d70\"}", 1L, 1L, 12345.6789, null, 1733813310170L, 1733813310170L, false)
+    )
+
+    // Create Data Pool to Filesystem
+    val poolDataFrame = spark.createDataFrame(spark.sparkContext.parallelize(rows), schemaStruct)
+    poolDataFrame
+      .write
+      .mode(SaveMode.Overwrite)
+      .parquet(dataPoolPath)
+  }
+
+  override def afterAll(): Unit = {
+    val path = new Path(dataPoolPath)
+    val fileSystem = path.getFileSystem(new Configuration())
+
+    // Delete Data Pool from Filesystem
+    if (fileSystem.exists(path)) {
+      fileSystem.delete(path, true)
+    }
+  }
+
+  test("Loading and deduplicating MongoDB data pool should return a valid DataPool") {
+    val kafkaTopic = "mongodbstaging.github_staging.transactions"
+    val kafkaBootstrapServers = "localhost:9092"
+    val startScheduledTimestamp = LocalDateTime.parse("2024-12-09T17:00:00")
+    val endScheduledTimestamp = LocalDateTime.parse("2024-12-10T17:00:00")
+    val dataLakePath = "build/tmp"
+
+    val jsonFile = "src/test/resources/kafka/mongodb/github_staging_transactions.json"
+    val testingDataFrame = spark.read.option("multiline", "true").json(jsonFile)
+
+    val (_, curatedLakeDataFrame) = Kafka
+      .read(kafkaTopic)
+      .withKafkaBootstrapServers(kafkaBootstrapServers)
+      .withTimeRange(startScheduledTimestamp, endScheduledTimestamp)
+      .withTable(table)
+      .withDataLakePath(dataLakePath)
+      .loadAndWriteDataLake(isTesting = true, Some(testingDataFrame))
+
+    val poolDataFrame = DataPool
+      .forPath(dataPoolPath)
+      .mergeWith(curatedLakeDataFrame)
+      .withTable(table)
+      .load()
+
+    val expectedPoolDataFrame = Array(
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d70\"}", 1L, 1L, 12345.6789, null, 1733813310170L, 1733813310170L, false),
+      Row("{\"$oid\":\"630b23db6ef80123d6e72d74\"}", 2L, 2L, 12345.67892, "{\"user\":\"data\",\"status\":\"PAID\"}", 1733813319170L, 1733813323170L, true)
+    )
+
+    poolDataFrame.collect() should contain theSameElementsAs expectedPoolDataFrame
+  }
+}

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataPoolMySqlTransformerTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataPoolMySqlTransformerTest.scala
@@ -1,0 +1,97 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.batch.helpers.SchemaConverter
+import com.github.davidch93.etl.core.schema.{SchemaLoader, Table}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+class DataPoolMySqlTransformerTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
+
+  val spark: SparkSession = SparkSession.builder().master("local[1]").getOrCreate()
+
+  val schemaFilePath = "src/test/resources/schema/mysql/github_staging_orders/schema.json"
+  val table: Table = SchemaLoader.loadTableSchema(schemaFilePath)
+
+  val dataPoolPath = "build/tmp/test/mysql/github_staging_orders/snapshot=2024-12-09"
+
+  override def beforeAll(): Unit = {
+    spark.sparkContext.setLogLevel("WARN")
+
+    val tablePartitionOpt = Option(table.getTablePartition.orElse(null))
+    val schemaStruct = SchemaConverter.tableSchemaWithMetadataToStructType(table.getSchema, tablePartitionOpt)
+
+    val rows = Seq(
+      Row(1L, 250000.0, "CANCELLED", false, 1733813310170L, new Timestamp(1733813310000L), false)
+    )
+
+    // Create Data Pool to Filesystem
+    val poolDataFrame = spark.createDataFrame(spark.sparkContext.parallelize(rows), schemaStruct)
+    poolDataFrame
+      .write
+      .mode(SaveMode.Overwrite)
+      .parquet(dataPoolPath)
+  }
+
+  override def afterAll(): Unit = {
+    val path = new Path(dataPoolPath)
+    val fileSystem = path.getFileSystem(new Configuration())
+
+    // Delete Data Pool from Filesystem
+    if (fileSystem.exists(path)) {
+      fileSystem.delete(path, true)
+    }
+  }
+
+  test("Loading and deduplicating MySQL data pool with a partition column should return a valid DataPool") {
+    val kafkaTopic = "mysqlstaging.github_staging.orders"
+    val kafkaBootstrapServers = "localhost:9092"
+    val startScheduledTimestamp = LocalDateTime.parse("2024-12-09T17:00:00")
+    val endScheduledTimestamp = LocalDateTime.parse("2024-12-10T17:00:00")
+    val dataLakePath = "build/tmp"
+
+    val jsonFile = "src/test/resources/kafka/mysql/github_staging_orders.json"
+    val testingDataFrame = spark.read.option("multiline", "true").json(jsonFile)
+
+    val (_, curatedLakeDataFrame) = Kafka
+      .read(kafkaTopic)
+      .withKafkaBootstrapServers(kafkaBootstrapServers)
+      .withTimeRange(startScheduledTimestamp, endScheduledTimestamp)
+      .withTable(table)
+      .withDataLakePath(dataLakePath)
+      .loadAndWriteDataLake(isTesting = true, Some(testingDataFrame))
+
+    val poolDataFrame = DataPool
+      .forPath(dataPoolPath)
+      .mergeWith(curatedLakeDataFrame)
+      .withTable(table)
+      .load()
+
+    val expectedPoolDataFrame = Array(
+      Row(1L, 250000.0, "CANCELLED", false, 1733813310170L, new Timestamp(1733813310000L), false),
+      Row(2L, 150000.0, "PAID", true, 1733813319170L, new Timestamp(1733813319000L), true)
+    )
+
+    poolDataFrame.collect() should contain theSameElementsAs expectedPoolDataFrame
+  }
+
+  test("Loading MySQL data pool with an empty data lake should return a valid DataPool without deduplicating") {
+    val poolDataFrame = DataPool
+      .forPath(dataPoolPath)
+      .mergeWith(spark.emptyDataFrame)
+      .withTable(table)
+      .load()
+
+    val expectedPoolDataFrame = Array(
+      Row(1L, 250000.0, "CANCELLED", false, 1733813310170L, new Timestamp(1733813310000L), false)
+    )
+
+    poolDataFrame.collect() should contain theSameElementsAs expectedPoolDataFrame
+  }
+}

--- a/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataPoolPostgreSqlTransformerTest.scala
+++ b/etl-batch/src/test/scala/com/github/davidch93/etl/batch/transformers/DataPoolPostgreSqlTransformerTest.scala
@@ -1,0 +1,82 @@
+package com.github.davidch93.etl.batch.transformers
+
+import com.github.davidch93.etl.batch.helpers.SchemaConverter
+import com.github.davidch93.etl.core.schema.{SchemaLoader, Table}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDateTime
+
+class DataPoolPostgreSqlTransformerTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
+
+  val spark: SparkSession = SparkSession.builder().master("local[1]").getOrCreate()
+
+  val schemaFilePath = "src/test/resources/schema/postgresql/github_staging_users/schema.json"
+  val table: Table = SchemaLoader.loadTableSchema(schemaFilePath)
+
+  val dataPoolPath = "build/tmp/test/postgresql/github_staging_users/snapshot=2024-12-09"
+
+  override def beforeAll(): Unit = {
+    spark.sparkContext.setLogLevel("WARN")
+
+    val tablePartitionOpt = Option(table.getTablePartition.orElse(null))
+    val schemaStruct = SchemaConverter.tableSchemaWithMetadataToStructType(table.getSchema, tablePartitionOpt)
+
+    val rows = Seq(
+      Row(1L, "data-user@example.com", 1733813310170L, 1733813310170L, false)
+    )
+
+    // Create Data Pool to Filesystem
+    val poolDataFrame = spark.createDataFrame(spark.sparkContext.parallelize(rows), schemaStruct)
+    poolDataFrame
+      .write
+      .mode(SaveMode.Overwrite)
+      .parquet(dataPoolPath)
+  }
+
+  override def afterAll(): Unit = {
+    val path = new Path(dataPoolPath)
+    val fileSystem = path.getFileSystem(new Configuration())
+
+    // Delete Data Pool from Filesystem
+    if (fileSystem.exists(path)) {
+      fileSystem.delete(path, true)
+    }
+  }
+
+  test("Loading and deduplicating PostgreSQL data pool should return a valid DataPool") {
+    val kafkaTopic = "postgresqlstaging.github_staging.users"
+    val kafkaBootstrapServers = "localhost:9092"
+    val startScheduledTimestamp = LocalDateTime.parse("2024-12-09T17:00:00")
+    val endScheduledTimestamp = LocalDateTime.parse("2024-12-10T17:00:00")
+    val dataLakePath = "build/tmp"
+
+    val jsonFile = "src/test/resources/kafka/postgresql/github_staging_users.json"
+    val testingDataFrame = spark.read.option("multiline", "true").json(jsonFile)
+
+    val (_, curatedLakeDataFrame) = Kafka
+      .read(kafkaTopic)
+      .withKafkaBootstrapServers(kafkaBootstrapServers)
+      .withTimeRange(startScheduledTimestamp, endScheduledTimestamp)
+      .withTable(table)
+      .withDataLakePath(dataLakePath)
+      .loadAndWriteDataLake(isTesting = true, Some(testingDataFrame))
+
+    val poolDataFrame = DataPool
+      .forPath(dataPoolPath)
+      .mergeWith(curatedLakeDataFrame)
+      .withTable(table)
+      .load()
+
+    val expectedPoolDataFrame = Array(
+      Row(1L, "data-user@example.com", 1733813310170L, 1733813310170L, false),
+      Row(2L, null, null, null, true)
+    )
+
+    poolDataFrame.collect() should contain theSameElementsAs expectedPoolDataFrame
+  }
+}

--- a/etl-core/src/main/java/com/github/davidch93/etl/core/constants/MetadataField.java
+++ b/etl-core/src/main/java/com/github/davidch93/etl/core/constants/MetadataField.java
@@ -68,6 +68,7 @@ public final class MetadataField {
     public static final String LSN = "_lsn";
     public static final String SHARD_ID = "_shard_id";
     public static final String SEQUENCE_NUMBER = "_sequence_number";
+    public static final String ROW_NUMBER = "_row_number";
     public static final String AUDIT_WRITE_TIME = "_audit_write_time";
 
     // DateTime & Timestamp Format


### PR DESCRIPTION
## Updates
- [x] Added Data Pool transformers in the `etl-batch` module.
  - [x] `DataPoolDynamoDbTransformer`
  - [x] `DataPoolMongoDbTransformer`
  - [x] `DataPoolMySqlTransformer`
  - [x] `DataPoolPostgreSqlTransformer`
- [x] Added an `UnsupportedOperationException` in `Kafka` class.
- [x] Added a new metadata field of `ROW_NUMBER`.